### PR TITLE
New feature - instance type randomization

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,10 @@ docker run --rm --name pg1 -e PGSO_INSTANCE_NAME=pg1 -e PGSO_REGION=eu-north-1 \
   -e PGSO_SETUP_FINISHED_CALLBACK="/my_callback.sh" -v "$HOME/my_callback.sh":/my_callback.sh \
   pgspotops/pg-spot-operator:latest
 ```
+
+# Reducing downtime / eviction rates
+
+Currently the instance type selection logic is very simple - by default we take the cheapest instance type matching
+the hardware requirements, which can lead to non-optimal eviction rates. To combat that one can:
+ * Specify target instance types explicitly via the *vm.instance_types* attribute
+ * Enable instance type randomize_instance_types=true and set *cpu_max=x* to contain the costs

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -71,6 +71,9 @@ class ArgumentParser(Tap):
     region: str = os.getenv("PGSO_REGION", "")
     zone: str = os.getenv("PGSO_ZONE", "")
     cpu_min: int = int(os.getenv("PGSO_CPU_MIN", "0"))
+    cpu_max: int = int(
+        os.getenv("PGSO_CPU_MAX", "0")
+    )  # Infers randomize_instance_types=True
     ram_min: int = int(os.getenv("PGSO_RAM_MIN", "0"))
     storage_min: int = int(os.getenv("PGSO_STORAGE_MIN", "0"))
     storage_type: str = os.getenv("PGSO_STORAGE_TYPE", "network")
@@ -143,6 +146,9 @@ instance_name: {args.instance_name}
         mfs += f"  cpu_architecture: {args.cpu_architecture}\n"
     if args.cpu_min:
         mfs += f"  cpu_min: {args.cpu_min}\n"
+    if args.cpu_max:
+        mfs += f"  cpu_max: {args.cpu_max}\n"
+        mfs += "  randomize_instance_types: true\n"
     if args.ram_min:
         mfs += f"  ram_min: {args.ram_min}\n"
     if args.storage_min:

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -14,6 +14,7 @@ def get_cheapest_skus_for_hardware_requirements(
     max_skus_to_get: int = 1,
     skus_to_avoid: list[str] | None = None,
 ) -> list[ResolvedInstanceTypeInfo]:
+    """Returns a lowest-price-first list"""
     logger.debug(
         "Looking for the cheapest Spot VM for following HW reqs: %s",
         [x for x in m.vm.dict().items() if x[1] is not None],
@@ -25,6 +26,7 @@ def get_cheapest_skus_for_hardware_requirements(
             availability_zone=m.availability_zone,
             cpu_min=m.vm.cpu_min,
             cpu_max=m.vm.cpu_max,
+            randomize_instance_types=m.vm.randomize_instance_types,
             ram_min=m.vm.ram_min,
             architecture=m.vm.cpu_architecture,
             storage_type=m.vm.storage_type,

--- a/pg_spot_operator/cloud_impl/aws_spot.py
+++ b/pg_spot_operator/cloud_impl/aws_spot.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from collections import defaultdict
 from datetime import datetime, timedelta
 from statistics import mean
@@ -266,6 +267,7 @@ def get_cheapest_sku_for_hw_reqs(
     availability_zone: str | None = None,
     cpu_min: int = 0,
     cpu_max: int = 0,
+    randomize_instance_types: bool = False,
     ram_min: int = 0,
     architecture: str = "any",
     storage_type: str = "network",
@@ -322,7 +324,13 @@ def get_cheapest_sku_for_hw_reqs(
     avg_by_sku_az = get_avg_spot_price_from_pricing_history_data_by_sku_and_az(
         hourly_pricing_data
     )
-    sku, az, price = avg_by_sku_az[0]
+    if randomize_instance_types:
+        sku, az, price = random.choice(avg_by_sku_az)
+        logger.debug(
+            "Chose a random SKU %s due to randomize_instance_types set", sku
+        )
+    else:
+        sku, az, price = avg_by_sku_az[0]
 
     arch: str = ""
     i_desc: dict = {}

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -54,6 +54,7 @@ class SectionVm(BaseModel):
     detailed_monitoring: bool = False  # Has extra cost
     cpu_min: int = 0
     cpu_max: int = 0
+    randomize_instance_types: bool = False
     ram_min: int = 0
     storage_min: int = 0
     storage_type: str = "network"


### PR DESCRIPTION
To help with bad eviction rates in case HW reqs resolve to a too popular instance type that gets evicted too much. Works in conjunction with *cpu_max* to cap the costs

https://github.com/pg-spot-ops/pg-spot-operator/issues/13
