### PR TITLE
Support adding extensions over the CLI

### DIFF
--- a/ansible/v1/roles/init_pg_instance/tasks/optional_user_db_setup.yml
+++ b/ansible/v1/roles/init_pg_instance/tasks/optional_user_db_setup.yml
@@ -50,3 +50,15 @@
     login_host: /var/run/postgresql
     login_port: "5432"
   when: postgresql.app_db_name | d('') | length > 0
+
+- name: Add user listed extensions to the default or app db
+  become: true
+  become_user: postgres
+  community.postgresql.postgresql_ext:
+    db: "{{ postgresql.app_db_name | d('') or 'postgres' }}"
+    name: "{{ item }}"
+    login_host: /var/run/postgresql
+    login_port: "5432"
+    cascade: true
+  loop: "{{ postgresql.extensions }}"
+  when: postgresql.extensions | d([])

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -109,6 +109,7 @@ class ArgumentParser(Tap):
     shared_preload_libraries: str = os.getenv(
         "PGSO_SHARED_PRELOAD_LIBRARIES", "pg_stat_statements"
     )  # Comma separated
+    extensions: str = os.getenv("PGSO_EXTENSIONS", "pg_stat_statements")
     aws_access_key_id: str = os.getenv("PGSO_AWS_ACCESS_KEY_ID", "")
     aws_secret_access_key: str = os.getenv("PGSO_AWS_SECRET_ACCESS_KEY", "")
     aws_security_group_ids: str = os.getenv(
@@ -227,6 +228,8 @@ def compile_manifest_from_cmdline_params(
         m.postgresql.config_lines.append(
             f"shared_preload_libraries = '{args.shared_preload_libraries.rstrip("'").lstrip("'")}'"
         )
+    if args.extensions:
+        m.postgresql.extensions = args.extensions.strip().split(",")
     if args.os_extra_packages:
         m.os.extra_packages = args.os_extra_packages.strip().split(",")
 

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -103,6 +103,12 @@ class ArgumentParser(Tap):
     admin_user: str = os.getenv("PGSO_ADMIN_USER", "")
     admin_user_password: str = os.getenv("PGSO_ADMIN_USER_PASSWORD", "")
     admin_is_superuser: str = os.getenv("PGSO_ADMIN_IS_SUPERUSER", "false")
+    os_extra_packages: str = os.getenv(
+        "PGSO_OS_EXTRA_PACKAGES", ""
+    )  # Comma separated, e.g. postgresql-16-postgis-3
+    shared_preload_libraries: str = os.getenv(
+        "PGSO_SHARED_PRELOAD_LIBRARIES", "pg_stat_statements"
+    )  # Comma separated
     aws_access_key_id: str = os.getenv("PGSO_AWS_ACCESS_KEY_ID", "")
     aws_secret_access_key: str = os.getenv("PGSO_AWS_SECRET_ACCESS_KEY", "")
     aws_security_group_ids: str = os.getenv(
@@ -217,6 +223,12 @@ def compile_manifest_from_cmdline_params(
     m.postgresql.admin_user_password = args.admin_user_password
     m.postgresql.admin_is_superuser = str_to_bool(args.admin_is_superuser)
     m.postgresql.tuning_profile = args.tuning_profile
+    if args.shared_preload_libraries:
+        m.postgresql.config_lines.append(
+            f"shared_preload_libraries = '{args.shared_preload_libraries.rstrip("'").lstrip("'")}'"
+        )
+    if args.os_extra_packages:
+        m.os.extra_packages = args.os_extra_packages.strip().split(",")
 
     if args.backup_s3_bucket:
         m.backup.type = "pgbackrest"

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -226,7 +226,9 @@ def compile_manifest_from_cmdline_params(
     m.postgresql.tuning_profile = args.tuning_profile
     if args.shared_preload_libraries:
         m.postgresql.config_lines.append(
-            f"shared_preload_libraries = '{args.shared_preload_libraries.rstrip("'").lstrip("'")}'"
+            "shared_preload_libraries = '"
+            + args.shared_preload_libraries.rstrip("'").lstrip("'")
+            + "'"
         )
     if args.extensions:
         m.postgresql.extensions = args.extensions.strip().split(",")

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -105,7 +105,7 @@ class ArgumentParser(Tap):
     admin_is_superuser: str = os.getenv("PGSO_ADMIN_IS_SUPERUSER", "false")
     os_extra_packages: str = os.getenv(
         "PGSO_OS_EXTRA_PACKAGES", ""
-    )  # Comma separated, e.g. postgresql-16-postgis-3
+    )  # Comma separated, e.g. postgresql-16-postgis-3,postgresql-16-pgrouting
     shared_preload_libraries: str = os.getenv(
         "PGSO_SHARED_PRELOAD_LIBRARIES", "pg_stat_statements"
     )  # Comma separated

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -54,6 +54,7 @@ class SectionPostgresql(BaseModel):
     admin_is_superuser: bool = False
     app_db_name: str | None = None
     config_lines: list[str] = field(default_factory=list)
+    extensions: list[str] = field(default_factory=list)
     pg_hba_lines: list[str] = field(default_factory=list)
     initdb_opts: list[str] = field(default_factory=list)
 


### PR DESCRIPTION
3 new CLI flags --os-extra-packages, --shared-preload-libraries, --extensions and 1 manifest attribute `postgresql.extensions`  to do a pre-create via Ansible, as can't be done later by user if in non-superuser mode.

To enable non core extensions like postgis or timescaledb. By default load pg_stat_statements only.


```
... --admin-is-superuser false --shared-preload-libraries pg_stat_statements,timescaledb --extensions pg_stat_statements,pgstattuple,timescaledb --os-extra-packages postgresql-16-timescaledb,postgresql-16-postgis-3
```