### PR TITLE
Show progress messages still in --connstr-output-only mode

### DIFF
--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -521,11 +521,7 @@ def main():  # pragma: no cover
             if args.verbose
             else "%(asctime)s %(levelname)s %(message)s"
         ),
-        level=(
-            logging.ERROR
-            if args.connstr_output_only
-            else logging.DEBUG if args.verbose else logging.INFO
-        ),
+        level=(logging.DEBUG if args.verbose else logging.INFO),
     )
 
     if args.show_help:


### PR DESCRIPTION
The silence could be a bit too scary.

Should not ruin pipe mode usage as logs go to stderr but connstr to stdout