### PR TITLE
Don't create a NIC in floating IP mode

### DIFF
--- a/example_manifests/hello_aws.yaml
+++ b/example_manifests/hello_aws.yaml
@@ -6,8 +6,9 @@ region: eu-south-2  # Optional if availability_zone set
 availability_zone: eu-south-2b  # Optional
 instance_name: hello-aws  # Required
 description: My play instance # Optional
-assign_public_ip: true  # Default: true
-floating_ips: true  # Default: true. If false and assign_public_ip set an Elastic IPs will be used (very limited per account)
+assign_public_ip: true  # Default: true. False = internal / VPC access only. PS Public IPs cost ~$4 per month.
+floating_ips: true  # Default: true. If true we get a new IP after eviction i.e. don't reserve / manage a NIC.
+                    # If false and assign_public_ip set an Elastic IPs will be used (given available, very limited per account)
 expiration_date: "2024-12-22 00:00+03"  # Optional. Instance will be deleted after that (if engine running)
 self_terminate: false  # Optional. Instance will auto-destroy itself (if AWS keys )
 is_paused: false  # No engine actions on the instance

--- a/example_manifests/hello_aws.yaml
+++ b/example_manifests/hello_aws.yaml
@@ -7,7 +7,7 @@ availability_zone: eu-south-2b  # Optional
 instance_name: hello-aws  # Required
 description: My play instance # Optional
 assign_public_ip: true  # Default: true
-floating_public_ip: true  # Default: true, as Elastic IPs are very limited per account
+floating_ips: true  # Default: true. If false and assign_public_ip set an Elastic IPs will be used (very limited per account)
 expiration_date: "2024-12-22 00:00+03"  # Optional. Instance will be deleted after that (if engine running)
 self_terminate: false  # Optional. Instance will auto-destroy itself (if AWS keys )
 is_paused: false  # No engine actions on the instance

--- a/pg_spot_operator/cloud_impl/aws_vm.py
+++ b/pg_spot_operator/cloud_impl/aws_vm.py
@@ -388,9 +388,9 @@ def ec2_launch_instance(
     network_interface: dict[str, Any] = {
         "AssociatePublicIpAddress": False,
         "DeviceIndex": 0,
-        "DeleteOnTermination": False,
+        "DeleteOnTermination": m.floating_ips,
     }
-    if m.floating_public_ip and m.assign_public_ip:
+    if m.floating_ips and m.assign_public_ip:
         network_interface["AssociatePublicIpAddress"] = True
     if subnet_id:
         network_interface["SubnetId"] = subnet_id
@@ -399,15 +399,16 @@ def ec2_launch_instance(
     logger.debug("network_interface %s", network_interface)
 
     existing_nic_found = False
-    nic_id = get_nic_id_if_any_by_id_tag(instance_name, region)
-    if nic_id:
-        existing_nic_found = True
-        wait_until_nic_available(nic_id, region)
-        network_interface = {
-            "DeviceIndex": 0,
-            "DeleteOnTermination": False,
-            "NetworkInterfaceId": nic_id,
-        }
+    if not m.floating_ips:
+        nic_id = get_nic_id_if_any_by_id_tag(instance_name, region)
+        if nic_id:
+            existing_nic_found = True
+            wait_until_nic_available(nic_id, region)
+            network_interface = {
+                "DeviceIndex": 0,
+                "DeleteOnTermination": False,
+                "NetworkInterfaceId": nic_id,
+            }
 
     kwargs_run: dict[str, Any] = {}
     if instance_type.startswith("t"):
@@ -431,7 +432,7 @@ def ec2_launch_instance(
                 "ResourceType": "network-interface",
                 "Tags": [
                     {
-                        "Key": "pg-spot-operator-instance",
+                        "Key": SPOT_OPERATOR_ID_TAG,
                         "Value": instance_name,
                     }
                 ],
@@ -851,7 +852,7 @@ def ensure_spot_vm(
     if m.vm.storage_type == STORAGE_TYPE_NETWORK:
         vol_desc = ensure_volume_attached(m, i_desc)
 
-    if m.assign_public_ip and not m.floating_public_ip:
+    if m.assign_public_ip and not m.floating_ips:
         pip = ensure_public_elastic_ip_attached(
             region, instance_name, i_desc["InstanceId"]
         )

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -170,8 +170,8 @@ class InstanceManifest(BaseModel):
     instance_name: str
     # Optional fields
     assign_public_ip: bool = True
-    floating_public_ip: bool = (
-        True  # Has only relevance if assign_public_ip set
+    floating_ips: bool = (
+        True  # If False NIC resources can be left hanging if not cleaned up properly
     )
     description: str = ""
     availability_zone: str = ""


### PR DESCRIPTION
One less resource to create + delete and wait on at teardown. Also of not floating (the default) and in --storage-type=local then there will be no resources hanging when one just terminates the instance from the CLI / portal (given engine stopped)

Rename floating_public_ip -> floating_ips

https://github.com/pg-spot-ops/pg-spot-operator/issues/7