### PR TITLE
New flag --ssh-private-key + Ansible manifest section

### DIFF
--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -366,19 +366,21 @@ def check_cli_args_valid(args: ArgumentParser):
             "Self-termination on expiration date requires --self-terminate-access-key-id and --self-terminate-secret-access-key",
         )
         exit(1)
-    if (
-        args.ssh_private_key
-        and not (
-            args.teardown
-            or args.teardown_region
-            or args.dry_run
-            or args.check_price
-            or args.check_manifest
-        )
-        and not os.path.exists(os.path.expanduser(args.ssh_private_key))
+    if args.ssh_private_key and not (
+        args.teardown
+        or args.teardown_region
+        or args.dry_run
+        or args.check_price
+        or args.check_manifest
     ):
-        logger.error("--ssh-private-key file not found")
-        exit(1)
+        if not os.path.exists(os.path.expanduser(args.ssh_private_key)):
+            logger.error("--ssh-private-key file not found")
+            exit(1)
+        if not os.path.exists(
+            os.path.expanduser(args.ssh_private_key + ".pub")
+        ):
+            logger.error("--ssh-private-key .pub file not found")
+            exit(1)
 
 
 def try_load_manifest(manifest_str: str) -> InstanceManifest | None:

--- a/pg_spot_operator/cloud_impl/aws_vm.py
+++ b/pg_spot_operator/cloud_impl/aws_vm.py
@@ -814,10 +814,16 @@ def ensure_spot_vm(
             f"Instance {i_desc['InstanceId']} already running for instance {instance_name}, skipping create"
         )
     else:
+        pub_key_file = "~/.ssh/id_rsa.pub"
+        if m.ansible.private_key:
+            if m.ansible.private_key.endswith(".pub"):
+                pub_key_file = m.ansible.private_key
+            else:
+                pub_key_file = m.ansible.private_key + ".pub"
         user_data = compile_cloud_init_user_data_config(
             region,
             LOGIN_USER,
-            "~/.ssh/id_rsa.pub",
+            pub_key_file,
             m.os.ssh_pub_keys,
             m.aws.key_pair_name,
         )

--- a/pg_spot_operator/cmdb.py
+++ b/pg_spot_operator/cmdb.py
@@ -518,6 +518,8 @@ def get_ssh_connstr(m: InstanceManifest) -> str:
     vm = get_latest_vm_by_uuid(m.uuid)
     if not vm:
         return ""
+    if m.ansible.private_key:
+        return f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=1 -l {vm.login_user} -i {m.ansible.private_key} {vm.ip_public or vm.ip_private}"
     return f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=1 -l {vm.login_user} {vm.ip_public or vm.ip_private}"
 
 

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -46,6 +46,10 @@ def ignore(loader, tag, node):
 yaml.add_multi_constructor("!", ignore, Loader=yaml.SafeLoader)
 
 
+class SectionAnsible(BaseModel):
+    private_key: str = ""
+
+
 class SectionPostgresql(BaseModel):
     version: int = DEFAULT_POSTGRES_MAJOR_VER
     tuning_profile: str = "default"
@@ -188,6 +192,7 @@ class InstanceManifest(BaseModel):
     os: SectionOs = field(default_factory=SectionOs)
     aws: SectionAws = field(default_factory=SectionAws)
     monitoring: SectionMonitoring = field(default_factory=SectionMonitoring)
+    ansible: SectionAnsible = field(default_factory=SectionAnsible)
 
     @staticmethod
     def get_internal_usage_attributes() -> set:

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -184,13 +184,13 @@ class NoAliasDumper(yaml.SafeDumper):
 
 
 def get_ansible_inventory_file_str_for_action(
-    action: str, uuid: str, instance_name: str
+    action: str, m: InstanceManifest
 ) -> str:
     groups: dict = {"all": {"hosts": {}}}
     logging.debug(
         "Putting together required inventory for action %s of %s ...",
         action,
-        instance_name,
+        m.instance_name,
     )
     if action in [
         constants.ACTION_ENSURE_VM,
@@ -201,14 +201,16 @@ def get_ansible_inventory_file_str_for_action(
         groups["all"]["hosts"]["localhost"] = {}
         return yaml.dump(groups, Dumper=NoAliasDumper)
 
-    vm = cmdb.get_latest_vm_by_uuid(uuid)
+    vm = cmdb.get_latest_vm_by_uuid(m.uuid)
     if not vm:
         raise Exception(
-            f"No active VM found for instance {instance_name} UUID {uuid} to compile an inventory file"
+            f"No active VM found for instance {m.instance_name} to compile an inventory file"
         )
     host_vars = {"ansible_user": vm.login_user}
     if vm.ip_public:
         host_vars["ansible_host"] = vm.ip_public
+    if m.ansible.private_key:
+        host_vars["ansible_ssh_private_key_file"] = m.ansible.private_key
 
     groups["all"]["hosts"][vm.ip_private] = host_vars
 
@@ -220,11 +222,16 @@ def generate_ansible_inventory_file_for_action(
 ):
     """Places an inventory file into temp_workdir"""
     if m.vm.host and m.vm.login_user:
-        inventory = f"{m.vm.host} ansible_user={m.vm.login_user}"
+        inventory = (
+            f"{m.vm.host} ansible_user={m.vm.login_user}"
+            + f" ansible_ssh_private_key_file={m.ansible.private_key}"
+            if m.ansible.private_key
+            else ""
+        )
     elif dry_run:
         inventory = "dummy"
     else:
-        inventory = get_ansible_inventory_file_str_for_action(action, m.uuid, m.instance_name)  # type: ignore
+        inventory = get_ansible_inventory_file_str_for_action(action, m)
     if not inventory:
         raise Exception(
             f"Could not compile inventory for action {action} of instance {m.instance_name}"

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -1010,7 +1010,9 @@ def do_main_loop(
                     m.vm.host,
                 )
                 if cli_dry_run:
-                    ssh_ok = check_ssh_ping_ok(m.vm.login_user, m.vm.host)
+                    ssh_ok = check_ssh_ping_ok(
+                        m.vm.login_user, m.vm.host, m.ansible.private_key
+                    )
                     if not ssh_ok:
                         raise Exception("Could not SSH connect to --vm-host")
                     logger.info("SSH connect OK")
@@ -1031,13 +1033,8 @@ def do_main_loop(
                 vm_created_recreated
                 or diff
                 or not current_manifest_applied_successfully
-                and not cli_vm_only
             ):
                 # Just reconfigure the VM if any changes discovered, relying on Ansible idempotence
-                logging.info(
-                    "Re-configuring Postgres for instance %s ...",
-                    m.instance_name,
-                )
                 if diff:
                     logging.info("Detected manifest changes: %s", diff)
 

--- a/pg_spot_operator/util.py
+++ b/pg_spot_operator/util.py
@@ -179,22 +179,22 @@ def try_rm_file_if_exists(file_path: str) -> None:
         logger.exception(f"Failed to remove file at {file_path}")
 
 
-def check_ssh_ping_ok(login: str, host: str) -> bool:
+def check_ssh_ping_ok(
+    login: str, host: str, private_key_file: str = ""
+) -> bool:
     try:
         logger.debug("Testing SSH connection to %s@%s ...", login, host)
-        rc, _ = run_process_with_output(
-            "ssh",
-            [
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "UserKnownHostsFile=/dev/null",
-                "-l",
-                login,
-                host,
-                "date",
-            ],
-        )
+        ssh_args = [
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-l",
+            login,
+        ]
+        if private_key_file:
+            ssh_args += ["-i", private_key_file]
+        rc, _ = run_process_with_output("ssh", ssh_args + [host, "date"])
         logger.debug("Retcode: %s", rc)
         return rc == 0
     except Exception as e:


### PR DESCRIPTION
Currently the engine expected and used the default SSH key for Ansible access.  New manifest section as proably need to add all other Ansible connection opts also to support ProxyCommand etc.

The key still cannot be password protected!

```
python3 -m pg_spot_operator --verbose  --region eu-north-1 --instance-name hello1 --storage-type local --storage-min 10 --ssh-private-key ~/.ssh/google_compute_engine
```

