### PR TITLE
Auto-download ansible setup scripts from GitHub if missing

### DIFF
--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -271,7 +271,9 @@ def populate_temp_workdir_for_action_exec(
     logging.debug("Ensuring temp exec dir %s ...", temp_workdir)
     os.makedirs(temp_workdir, exist_ok=True)
 
-    handler_dir_to_fork = os.path.join(ansible_root_path, manifest.api_version)
+    handler_dir_to_fork = os.path.expanduser(
+        os.path.join(ansible_root_path, manifest.api_version)
+    )
     if not os.path.exists(handler_dir_to_fork):
         raise Exception(f"Ansible folder at {handler_dir_to_fork} not found")
     # Copy the whole Ansible dir for now into temp dir


### PR DESCRIPTION
To make `pip / pipx` usage more user-friendly - as Ansible not bundled to PyPI currently