### PR TITLE
New CLI flag: --aws-key-pair-name / PGSO_AWS_KEY_PAIR_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ the instance ...
 
 ```
 docker run --rm -e PGSO_INSTANCE_NAME=analytics -e PGSO_REGION=eu-north-1 -e PGSO_TEARDOWN=y \
-  -v ~/.aws:/root/.aws:ro -v ~/.ssh:/root/.ssh:ro \
+  -e PGSO_AWS_ACCESS_KEY_ID=abcdef -e PGSO_AWS_SECRET_ACCESS_KEY=qwerty \
   pgspotops/pg-spot-operator:latest
 
 ...
@@ -97,9 +97,10 @@ Note that by default we're in "daemon mode" - checking continuously for the inst
 ## Via Docker
 
 ```bash
-docker run --rm --name pg1 -e PGSO_INSTANCE_NAME=pg1 -e PGSO_REGION=eu-north-1 \
+docker run --rm --name pg1 -e PGSO_INSTANCE_NAME=pg1 -e PGSO_REGION=eu-north-1 -e PGSO_AWS_KEY_PAIR_NAME=mykey \
   -e PGSO_STORAGE_MIN=100 -e PGSO_STORAGE_TYPE=local -e PGSO_CPU_MIN=2 -e PGSO_POSTGRESQL_VERSION=16 \
   -e PGSO_EXTENSIONS=pgvector,pg_stat_statements -e PGSO_OS_EXTRA_PACKAGES=postgresql-16-pgvector \
+  -e PGSO_AWS_ACCESS_KEY_ID=abcdef -e PGSO_AWS_SECRET_ACCESS_KEY=qwerty \
   -v ~/.aws:/root/.aws:ro -v ~/.ssh:/root/.ssh:ro \
   pgspotops/pg-spot-operator:latest
 ```

--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -65,6 +65,7 @@
 * **--aws-subnet-id / PGSO_AWS_SUBNET_ID** To place the created VMs into a specific network
 * **--ssh-keys / PGSO_SSH_KEYS** Comma separated SSH pubkeys to add to the backing VM
 * **--ssh-private-key / PGSO_SSH_PRIVATE_KEY** (Default: ~/.ssh/id_rsa) To use a non-default SSH key to access the VM
+* **--aws-key-pair-name / PGSO_AWS_KEY_PAIR_NAME** To grant an existing AWS SSH key pair SSH access the VM. Must have the private key for actual access 
 
 # Backup
 

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -116,6 +116,7 @@ class ArgumentParser(Tap):
     extensions: str = os.getenv("PGSO_EXTENSIONS", "pg_stat_statements")
     aws_access_key_id: str = os.getenv("PGSO_AWS_ACCESS_KEY_ID", "")
     aws_secret_access_key: str = os.getenv("PGSO_AWS_SECRET_ACCESS_KEY", "")
+    aws_key_pair_name: str = os.getenv("PGSO_AWS_KEY_PAIR_NAME", "")
     aws_security_group_ids: str = os.getenv(
         "PGSO_AWS_SECURITY_GROUP_IDS", ""
     )  # SG rules are "merged" if multiple provided
@@ -220,6 +221,7 @@ def compile_manifest_from_cmdline_params(
     m.aws.subnet_id = args.aws_subnet_id
     m.aws.access_key_id = args.aws_access_key_id
     m.aws.secret_access_key = args.aws_secret_access_key
+    m.aws.key_pair_name = args.aws_key_pair_name
     m.self_terminate = args.self_terminate
     if args.self_terminate:
         m.aws.self_terminate_access_key_id = args.self_terminate_access_key_id

--- a/pg_spot_operator/cloud_impl/aws_vm.py
+++ b/pg_spot_operator/cloud_impl/aws_vm.py
@@ -247,18 +247,21 @@ def ensure_public_elastic_ip_attached(
 
 
 def get_key_pair_pubkey_if_any(region: str, ssh_key_pair_name: str) -> str:
-    """Throws an exception if can't read out the actual pubkey"""
+    """Swallows the exception if can't read out the actual pubkey as there are ways to specify keys"""
     if not ssh_key_pair_name:
         return ""
     client = get_client("ec2", region)
-    response = client.describe_key_pairs(
-        KeyNames=[
-            ssh_key_pair_name,
-        ],
-        IncludePublicKey=True,
-    )
-    if response and "KeyPairs" in response:
-        return response["KeyPairs"][0]["PublicKey"].rstrip()
+    try:
+        response = client.describe_key_pairs(
+            KeyNames=[
+                ssh_key_pair_name,
+            ],
+            IncludePublicKey=True,
+        )
+        if response and "KeyPairs" in response:
+            return response["KeyPairs"][0]["PublicKey"].rstrip()
+    except Exception:
+        logger.exception(f"Failed to describe key pair {ssh_key_pair_name}")
     return ""
 
 


### PR DESCRIPTION
To specify an existing EC2 SSH key pair to access the VM. Other SSH key inputs also still effective