### PR TITLE
A new top level manifest attribute "vm_only" to skip the Postgres setup

### DIFF
--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -197,6 +197,7 @@ def compile_manifest_from_cmdline_params(
     m.expiration_date = args.expiration_date
     m.assign_public_ip = args.assign_public_ip
     m.setup_finished_callback = args.setup_finished_callback
+    m.vm_only = args.vm_only
     m.vm.cpu_architecture = args.cpu_architecture
     m.vm.cpu_min = args.cpu_min
     m.vm.cpu_max = args.cpu_max
@@ -648,7 +649,6 @@ def main():  # pragma: no cover
         cli_vault_password_file=args.vault_password_file,
         cli_user_manifest_path=args.manifest_path,
         cli_main_loop_interval_s=args.main_loop_interval_s,
-        cli_vm_only=args.vm_only,
         cli_destroy_file_base_path=args.destroy_file_base_path,
         cli_teardown=args.teardown,
         cli_connstr_output_only=args.connstr_output_only,

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -185,6 +185,7 @@ class InstanceManifest(BaseModel):
     setup_finished_callback: str = ""  # An executable passed to Ansible
     expiration_date: str = ""  # now | '2024-06-11 10:40'
     self_terminate: bool = False
+    vm_only: bool = False  # No Postgres setup
     is_paused: bool = False
     # *Sections*
     postgresql: SectionPostgresql = field(default_factory=SectionPostgresql)

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -1132,6 +1132,7 @@ def do_main_loop(
                     logger.info(
                         "*** SSH connect string *** - '%s'", get_ssh_connstr(m)
                     )
+                    cmdb.mark_manifest_snapshot_as_succeeded(m)
                 else:
                     run_action(constants.ACTION_INSTANCE_SETUP, m)
 

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -891,7 +891,6 @@ def do_main_loop(
     cli_user_manifest_path: str = "",
     cli_vault_password_file: str = "",
     cli_main_loop_interval_s: int = 60,
-    cli_vm_only: bool = False,
     cli_destroy_file_base_path: str = "",
     cli_teardown: bool = False,
     cli_connstr_output_only: bool = False,
@@ -1128,8 +1127,8 @@ def do_main_loop(
                 if diff:
                     logging.info("Detected manifest changes: %s", diff)
 
-                if cli_vm_only:
-                    logger.info("Skipping Postgres setup as --vm-only set")
+                if m.vm_only:
+                    logger.info("Skipping Postgres setup as vm_only set")
                     logger.info(
                         "*** SSH connect string *** - '%s'", get_ssh_connstr(m)
                     )


### PR DESCRIPTION
vm_only mode is useful for speeding up creation testing or when some ad-hoc / non-Postgres setup is wanted on the VM actually