### PR TITLE
Non auth price check

### DIFF
--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -481,7 +481,7 @@ def resolve_manifest_and_display_price(
         raise Exception("Valid InstanceManifest expected")
 
     logger.info(
-        "Resolving HW requirements to actual instance types / prices using instance selection strategy: %s ...",
+        "Resolving HW requirements to actual instance types / prices using --selection-strategy=%s ...",
         m.vm.instance_selection_strategy,
     )
 
@@ -530,16 +530,14 @@ def resolve_manifest_and_display_price(
             )
         )
     if sku.monthly_ondemand_price and sku.monthly_spot_price:
-        spot_discount = (
+        spot_discount_pct = (
             100.0
             * (sku.monthly_spot_price - sku.monthly_ondemand_price)
             / sku.monthly_ondemand_price
         )
         logger.info(
-            "Current Spot discount rate in %s %s: %s%% (spot $%s vs on-demand $%s)",
-            "AZ" if m.availability_zone else "region",
-            m.availability_zone if m.availability_zone else m.region,
-            round(spot_discount, 1),
+            "Current Spot discount rate: %s%% (spot $%s vs on-demand $%s)",
+            round(spot_discount_pct, 1),
             round(sku.monthly_spot_price, 1),
             round(sku.monthly_ondemand_price, 1),
         )
@@ -665,7 +663,7 @@ def main():  # pragma: no cover
     # Download the Ansible scripts if missing and in some "real" mode, as not bundled to PyPI currently
     download_ansible_from_github_if_not_set_locally(args)
 
-    logger.info("Entering main loop")
+    logger.debug("Entering main loop")
 
     operator.do_main_loop(
         cli_env_manifest=env_manifest,

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -485,18 +485,29 @@ def resolve_manifest_and_display_price(
         m.vm.instance_selection_strategy,
     )
 
-    # Set AWS creds
-    m.decrypt_secrets_if_any()
-    set_access_keys(
-        m.aws.access_key_id, m.aws.secret_access_key, m.aws.profile_name
-    )
+    # Set AWS creds if AZ set
+    if m.availability_zone and (
+        (m.aws.access_key_id and m.aws.secret_access_key) or m.aws.profile_name
+    ):
+        m.decrypt_secrets_if_any()
+        set_access_keys(
+            m.aws.access_key_id, m.aws.secret_access_key, m.aws.profile_name
+        )
 
-    cheapest_skus = cloud_api.get_cheapest_skus_for_hardware_requirements(m)
+        cheapest_skus = cloud_api.get_cheapest_skus_for_hardware_requirements(
+            m
+        )
+    else:
+        cheapest_skus = cloud_api.get_cheapest_skus_for_hardware_requirements(
+            m
+        )
+
     if not cheapest_skus:
         logger.error(
             f"No SKUs matching HW requirements found for instance {m.instance_name} in region / zone {m.region or m.availability_zone}"
         )
         exit(1)
+
     sku = cheapest_skus[0]
     logger.info("Instance type selected: %s (%s)", sku.instance_type, sku.arch)
     logger.info(

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -1,5 +1,6 @@
 import fcntl
 import logging
+import math
 import os.path
 
 import yaml
@@ -517,7 +518,8 @@ def resolve_manifest_and_display_price(
     )
 
     logger.info(
-        "Current monthly Spot price in %s %s: $%s",
+        "Current monthly Spot price for %s in %s %s: $%s",
+        sku.instance_type,
         "AZ" if m.availability_zone else "region",
         m.availability_zone if m.availability_zone else m.region,
         sku.monthly_spot_price,
@@ -536,10 +538,13 @@ def resolve_manifest_and_display_price(
             / sku.monthly_ondemand_price
         )
         logger.info(
-            "Current Spot discount rate: %s%% (spot $%s vs on-demand $%s)",
+            "Current Spot vs Ondemand discount rate: %s%% ($%s vs $%s), approx. %sx to non-HA RDS",
             round(spot_discount_pct, 1),
             round(sku.monthly_spot_price, 1),
             round(sku.monthly_ondemand_price, 1),
+            math.ceil(
+                sku.monthly_ondemand_price / sku.monthly_spot_price * 1.5
+            ),
         )
 
 

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -6,10 +6,15 @@ from pg_spot_operator.cloud_impl.aws_cache import (
 )
 from pg_spot_operator.cloud_impl.aws_spot import (
     get_all_ec2_spot_instance_types,
+    get_all_instance_types_from_aws_regional_pricing_info,
     get_current_hourly_ondemand_price_fallback,
     get_current_hourly_spot_price,
+    get_spot_instance_types_with_price_from_s3_pricing_json,
 )
 from pg_spot_operator.cloud_impl.cloud_structs import InstanceTypeInfo
+from pg_spot_operator.cloud_impl.cloud_util import (
+    extract_cpu_arch_from_sku_desc,
+)
 from pg_spot_operator.constants import (
     CLOUD_AWS,
     MF_SEC_VM_STORAGE_TYPE_LOCAL,
@@ -18,6 +23,33 @@ from pg_spot_operator.constants import (
 from pg_spot_operator.manifests import InstanceManifest
 
 logger = logging.getLogger(__name__)
+
+
+def boto3_api_instance_list_to_instance_type_info(
+    region: str, boto3_instance_type_infos: list[dict]
+) -> list[InstanceTypeInfo]:
+    ret = []
+    for ii in boto3_instance_type_infos:
+        sku = InstanceTypeInfo(
+            region=region,
+            cloud=CLOUD_AWS,
+            instance_type=ii["InstanceType"],
+            arch=extract_cpu_arch_from_sku_desc(CLOUD_AWS, ii),
+        )
+        sku.cpu = ii["VCpuInfo"]["DefaultVCpus"]
+        sku.ram_mb = ii["MemoryInfo"]["SizeInMiB"]
+        if ii.get("InstanceStorageSupported"):
+            sku.instance_storage = ii.get("InstanceStorageInfo", {}).get(
+                "TotalSizeInGB", 0
+            )
+        if ii.get("InstanceStorageInfo", {}).get("Disks"):
+            sku.storage_speed_class = ii["InstanceStorageInfo"]["Disks"][0][
+                "Type"
+            ]
+        sku.provider_description = ii
+        ret.append(sku)
+
+    return ret
 
 
 def get_cheapest_skus_for_hardware_requirements(
@@ -32,19 +64,36 @@ def get_cheapest_skus_for_hardware_requirements(
         "Looking for Spot VMs for following HW reqs: %s",
         [x for x in m.vm.dict().items() if x[1] is not None],
     )
-    if m.check_price and not (m.aws.access_key_id and m.aws.secret_access_key):
-        all_instances_for_region = get_aws_static_ondemand_pricing_info(
-            m.region
+    if check_price and not (m.aws.access_key_id and m.aws.secret_access_key):
+        all_instances_for_region = (
+            get_all_instance_types_from_aws_regional_pricing_info(
+                m.region, get_aws_static_ondemand_pricing_info(m.region)
+            )
         )
+        all_spot_instances_for_region_with_price = (
+            get_spot_instance_types_with_price_from_s3_pricing_json(
+                m.region, get_aws_static_ondemand_pricing_info(m.region)
+            )
+        )
+        all_regional_spots = []
+        for x in all_instances_for_region:
+            if all_spot_instances_for_region_with_price.get(x.instance_type):
+                x.hourly_spot_price = all_spot_instances_for_region_with_price[
+                    x.instance_type
+                ]
+                all_regional_spots.append(x)
     else:
-        all_instances_for_region = get_all_ec2_spot_instance_types(
+        all_boto3_instance_types_for_region = get_all_ec2_spot_instance_types(
             m.region,
             with_local_storage_only=(
                 m.vm.storage_type == MF_SEC_VM_STORAGE_TYPE_LOCAL
             ),
         )
+        all_regional_spots = boto3_api_instance_list_to_instance_type_info(
+            all_boto3_instance_types_for_region
+        )
     return aws_spot.get_cheapest_sku_for_hw_reqs(
-        all_instances_for_region,
+        all_regional_spots,
         m.region,
         availability_zone=m.availability_zone,
         cpu_min=m.vm.cpu_min,

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -110,6 +110,7 @@ def get_cheapest_skus_for_hardware_requirements(
         storage_min=m.vm.storage_min,
         allow_burstable=m.vm.allow_burstable,
         storage_speed_class=m.vm.storage_speed_class,
+        instance_types=m.vm.instance_types,
         instance_types_to_avoid=skus_to_avoid,
         instance_selection_strategy=m.vm.instance_selection_strategy,
     )

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -63,7 +63,8 @@ def get_cheapest_skus_for_hardware_requirements(
     """By default prefer to use the direct boto3 APIs to get the most fresh instance and pricing info.
     Use AWS static JSONs for unauthenticated price checks"""
     logger.debug(
-        "Looking for Spot VMs for following HW reqs: %s",
+        "Looking for Spot VMs via %s for following HW reqs: %s",
+        "boto3" if use_boto3 else "S3 price listings",
         [x for x in m.vm.dict().items() if x[1] is not None],
     )
 

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -1,12 +1,20 @@
 import logging
 
 from pg_spot_operator.cloud_impl import aws_spot
+from pg_spot_operator.cloud_impl.aws_cache import (
+    get_aws_static_ondemand_pricing_info,
+)
 from pg_spot_operator.cloud_impl.aws_spot import (
+    get_all_ec2_spot_instance_types,
     get_current_hourly_ondemand_price_fallback,
     get_current_hourly_spot_price,
 )
-from pg_spot_operator.cloud_impl.cloud_structs import ResolvedInstanceTypeInfo
-from pg_spot_operator.constants import CLOUD_AWS, SPOT_OPERATOR_ID_TAG
+from pg_spot_operator.cloud_impl.cloud_structs import InstanceTypeInfo
+from pg_spot_operator.constants import (
+    CLOUD_AWS,
+    MF_SEC_VM_STORAGE_TYPE_LOCAL,
+    SPOT_OPERATOR_ID_TAG,
+)
 from pg_spot_operator.manifests import InstanceManifest
 
 logger = logging.getLogger(__name__)
@@ -16,28 +24,40 @@ def get_cheapest_skus_for_hardware_requirements(
     m: InstanceManifest,
     max_skus_to_get: int = 1,
     skus_to_avoid: list[str] | None = None,
-) -> list[ResolvedInstanceTypeInfo]:
+    check_price: bool = False,
+) -> list[InstanceTypeInfo]:
+    """By default prefer to use the direct boto3 APIs to get the most fresh instance and pricing info.
+    Use AWS static JSONs for unauthenticated price checks"""
     logger.debug(
         "Looking for Spot VMs for following HW reqs: %s",
         [x for x in m.vm.dict().items() if x[1] is not None],
     )
-    if m.cloud == CLOUD_AWS:
-        return aws_spot.get_cheapest_sku_for_hw_reqs(
-            max_skus_to_get,
-            m.region,
-            availability_zone=m.availability_zone,
-            cpu_min=m.vm.cpu_min,
-            cpu_max=m.vm.cpu_max,
-            ram_min=m.vm.ram_min,
-            architecture=m.vm.cpu_architecture,
-            storage_type=m.vm.storage_type,
-            storage_min=m.vm.storage_min,
-            allow_burstable=m.vm.allow_burstable,
-            storage_speed_class=m.vm.storage_speed_class,
-            instance_types_to_avoid=skus_to_avoid,
-            instance_selection_strategy=m.vm.instance_selection_strategy,
+    if m.check_price and not (m.aws.access_key_id and m.aws.secret_access_key):
+        all_instances_for_region = get_aws_static_ondemand_pricing_info(
+            m.region
         )
-    return []
+    else:
+        all_instances_for_region = get_all_ec2_spot_instance_types(
+            m.region,
+            with_local_storage_only=(
+                m.vm.storage_type == MF_SEC_VM_STORAGE_TYPE_LOCAL
+            ),
+        )
+    return aws_spot.get_cheapest_sku_for_hw_reqs(
+        all_instances_for_region,
+        m.region,
+        availability_zone=m.availability_zone,
+        cpu_min=m.vm.cpu_min,
+        cpu_max=m.vm.cpu_max,
+        ram_min=m.vm.ram_min,
+        architecture=m.vm.cpu_architecture,
+        storage_type=m.vm.storage_type,
+        storage_min=m.vm.storage_min,
+        allow_burstable=m.vm.allow_burstable,
+        storage_speed_class=m.vm.storage_speed_class,
+        instance_types_to_avoid=skus_to_avoid,
+        instance_selection_strategy=m.vm.instance_selection_strategy,
+    )
 
 
 def get_all_operator_vms_in_manifest_region(

--- a/pg_spot_operator/cloud_impl/aws_cache.py
+++ b/pg_spot_operator/cloud_impl/aws_cache.py
@@ -4,19 +4,21 @@ import logging
 import os
 import time
 import urllib
-from datetime import date
+from datetime import date, datetime
 
 import requests
 
 from pg_spot_operator.constants import DEFAULT_CONFIG_DIR
 from pg_spot_operator.util import get_aws_region_code_to_name_mapping
 
+CONFIG_DIR_PRICE_CACHE_SUBDIR = "price_cache"
+
 logger = logging.getLogger(__name__)
 
 
 def get_cached_pricing_dict(cache_file: str) -> dict:
     cache_dir = os.path.expanduser(
-        os.path.join(DEFAULT_CONFIG_DIR, "price_cache")
+        os.path.join(DEFAULT_CONFIG_DIR, CONFIG_DIR_PRICE_CACHE_SUBDIR)
     )
     cache_path = os.path.join(cache_dir, cache_file)
     if os.path.exists(cache_path):
@@ -31,9 +33,11 @@ def get_cached_pricing_dict(cache_file: str) -> dict:
     return {}
 
 
-def cache_pricing_dict(cache_file: str, pricing_info: dict) -> None:
+def write_pricing_cache_file_as_json(
+    cache_file: str, pricing_info: dict
+) -> None:
     cache_dir = os.path.expanduser(
-        os.path.join(DEFAULT_CONFIG_DIR, "price_cache")
+        os.path.join(DEFAULT_CONFIG_DIR, CONFIG_DIR_PRICE_CACHE_SUBDIR)
     )
     cache_path = os.path.join(cache_dir, cache_file)
     os.makedirs(cache_dir, exist_ok=True)
@@ -69,15 +73,15 @@ def get_pricing_info_via_http(region: str) -> dict:
     return f.json()
 
 
-def clean_up_old_ondemad_pricing_cache_files(older_than_days: int) -> None:
+def clean_up_old_pricing_cache_files(older_than_days: int) -> None:
     """Delete old per region JSON files
     ~/.pg-spot-operator/price_cache/aws_ondemand_us-east-1_20241115.json
     """
     cache_dir = os.path.expanduser(
-        os.path.join(DEFAULT_CONFIG_DIR, "price_cache")
+        os.path.join(DEFAULT_CONFIG_DIR, CONFIG_DIR_PRICE_CACHE_SUBDIR)
     )
     epoch = time.time()
-    for pd in sorted(glob.glob(os.path.join(cache_dir, "aws_ondemand_*"))):
+    for pd in sorted(glob.glob(os.path.join(cache_dir, "aws_*"))):
         try:
             st = os.stat(pd)
             if epoch - st.st_mtime > 3600 * 24 * older_than_days:
@@ -95,12 +99,116 @@ def get_aws_static_ondemand_pricing_info(region: str) -> dict:
     if not pricing_info:
         pricing_info = get_pricing_info_via_http(region)
         if pricing_info:
-            cache_pricing_dict(cache_file, pricing_info)
-            clean_up_old_ondemad_pricing_cache_files(older_than_days=7)
+            write_pricing_cache_file_as_json(cache_file, pricing_info)
+            clean_up_old_pricing_cache_files(older_than_days=7)
         else:
             logger.error(
-                f"Failed to retrieve AWS ondemand pricing info for region %s",
+                "Failed to retrieve AWS ondemand pricing info for region %s",
                 region,
             )
             return {}
     return {}
+
+
+def get_latest_spot_pricing_json() -> dict:
+    """Return latest Spot JSON if any found.
+    Location: $config-dir/$price-cache/aws_spot_{now.year}{now.month}{now.day}_{now.hour}00.json
+    """
+    cache_dir = os.path.expanduser(
+        os.path.join(DEFAULT_CONFIG_DIR, CONFIG_DIR_PRICE_CACHE_SUBDIR)
+    )
+    g = glob.glob(os.path.join(cache_dir, "aws_spot_*"))
+    if g:
+        return json.load(open(sorted(g, reverse=True)[0]))
+    return {}
+
+
+def get_spot_pricing_from_public_json() -> dict:
+    """Via an AWS managed 2MB S3 JSON: https://website.spot.ec2.aws.a2z.com/spot.json
+    Caches locally into hourly aws_spot_* files
+    Response contains all regions and looks like:
+    {
+      "vers": 0.01,
+      "config": {
+        "rate": "perhr",
+        "valueColumns": [
+          "linux",
+          "mswin"
+        ],
+        "currencies": [
+          "USD"
+        ],
+        "regions": [
+          {
+            "region": "us-east-1",
+            "footnotes": {
+              "*": "notAvailableForCCorCGPU"
+            },
+            "instanceTypes": [
+              {
+                "type": "generalCurrentGen",
+                "sizes": [
+                  {
+                    "size": "m6i.xlarge",
+                    "valueColumns": [
+                      {
+                        "name": "linux",
+                        "prices": {
+                          "USD": "0.0615"
+                        }
+                      },
+                      {
+                        "name": "mswin",
+                        "prices": {
+                          "USD": "0.2032"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "size": "m6g.xlarge",
+                    "valueColumns": [
+                      {
+                        "name": "linux",
+                        "prices": {
+                          "USD": "0.0378"
+                        }
+                      },
+                      {
+                        "name": "mswin",
+                        "prices": {
+                          "USD": "N/A*"
+                        }
+                      }
+                    ]
+                  },
+    """
+    now = datetime.now()
+    cache_file = f"aws_spot_{now.year}{now.month}{now.day}_{now.hour}00.json"
+    spot_pricing_info = get_cached_pricing_dict(cache_file)
+    if spot_pricing_info:
+        return spot_pricing_info
+
+    url = "https://website.spot.ec2.aws.a2z.com/spot.json"
+    logger.debug("Fetching AWS spot pricing info from %s ...", url)
+    r = requests.get(
+        url, headers={"Content-Type": "application/json"}, timeout=5
+    )
+    if r.status_code != 200:
+        logger.error(
+            "Failed to retrieve AWS pricing info - retcode: %s, URL: %s",
+            r.status_code,
+            url,
+        )
+        latest_stored_spot_pricing_info = get_latest_spot_pricing_json()
+        if latest_stored_spot_pricing_info:
+            logger.warning(
+                "Using possibly outdated spot pricing from: %s",
+                latest_stored_spot_pricing_info,
+            )
+        return {}
+    spot_pricing_info = r.json()
+
+    write_pricing_cache_file_as_json(cache_file, spot_pricing_info)
+
+    return spot_pricing_info

--- a/pg_spot_operator/cloud_impl/aws_cache.py
+++ b/pg_spot_operator/cloud_impl/aws_cache.py
@@ -1,0 +1,106 @@
+import glob
+import json
+import logging
+import os
+import time
+import urllib
+from datetime import date
+
+import requests
+
+from pg_spot_operator.constants import DEFAULT_CONFIG_DIR
+from pg_spot_operator.util import get_aws_region_code_to_name_mapping
+
+logger = logging.getLogger(__name__)
+
+
+def get_cached_pricing_dict(cache_file: str) -> dict:
+    cache_dir = os.path.expanduser(
+        os.path.join(DEFAULT_CONFIG_DIR, "price_cache")
+    )
+    cache_path = os.path.join(cache_dir, cache_file)
+    if os.path.exists(cache_path):
+        logger.debug(
+            "Reading AWS pricing info from daily cache: %s", cache_path
+        )
+        try:
+            with open(cache_path, "r") as f:
+                return json.loads(f.read())
+        except Exception:
+            logger.error("Failed to read %s from AWS daily cache", cache_file)
+    return {}
+
+
+def cache_pricing_dict(cache_file: str, pricing_info: dict) -> None:
+    cache_dir = os.path.expanduser(
+        os.path.join(DEFAULT_CONFIG_DIR, "price_cache")
+    )
+    cache_path = os.path.join(cache_dir, cache_file)
+    os.makedirs(cache_dir, exist_ok=True)
+    with open(cache_path, "w") as f:
+        json.dump(pricing_info, f)
+
+
+def get_pricing_info_via_http(region: str) -> dict:
+    """AWS caches pricing info for public usage in static files like:
+    https://b0.p.awsstatic.com/pricing/2.0/meteredUnitMaps/ec2/USD/current/ec2-ondemand-without-sec-sel/EU%20(Stockholm)/Linux/index.json
+    """
+    region_location = get_aws_region_code_to_name_mapping().get(region, "")
+    if not region_location:
+        raise Exception(f"Could not map region code {region} to location name")
+    logger.debug(
+        f"Fetching AWS on-demand pricing info for region {region} ({region_location}) ..."
+    )
+
+    url = f"https://b0.p.awsstatic.com/pricing/2.0/meteredUnitMaps/ec2/USD/current/ec2-ondemand-without-sec-sel/{region_location}/Linux/index.json"
+
+    sanitized_url = urllib.parse.quote(url, safe=":/")
+    logger.debug("requests.get: %s", sanitized_url)
+    f = requests.get(
+        sanitized_url, headers={"Content-Type": "application/json"}, timeout=5
+    )
+    if f.status_code != 200:
+        logger.error(
+            "Failed to retrieve AWS pricing info - retcode: %s, URL: %s",
+            f.status_code,
+            url,
+        )
+        return {}
+    return f.json()
+
+
+def clean_up_old_ondemad_pricing_cache_files(older_than_days: int) -> None:
+    """Delete old per region JSON files
+    ~/.pg-spot-operator/price_cache/aws_ondemand_us-east-1_20241115.json
+    """
+    cache_dir = os.path.expanduser(
+        os.path.join(DEFAULT_CONFIG_DIR, "price_cache")
+    )
+    epoch = time.time()
+    for pd in sorted(glob.glob(os.path.join(cache_dir, "aws_ondemand_*"))):
+        try:
+            st = os.stat(pd)
+            if epoch - st.st_mtime > 3600 * 24 * older_than_days:
+                os.unlink(pd)
+        except Exception:
+            logger.info("Failed to clean up old on-demand pricing JSON %s", pd)
+
+
+def get_aws_static_ondemand_pricing_info(region: str) -> dict:
+    today = date.today()
+    cache_file = (
+        f"aws_ondemand_{region}_{today.year}{today.month}{today.day}.json"
+    )
+    pricing_info = get_cached_pricing_dict(cache_file)
+    if not pricing_info:
+        pricing_info = get_pricing_info_via_http(region)
+        if pricing_info:
+            cache_pricing_dict(cache_file, pricing_info)
+            clean_up_old_ondemad_pricing_cache_files(older_than_days=7)
+        else:
+            logger.error(
+                f"Failed to retrieve AWS ondemand pricing info for region %s",
+                region,
+            )
+            return {}
+    return {}

--- a/pg_spot_operator/cloud_impl/aws_cache.py
+++ b/pg_spot_operator/cloud_impl/aws_cache.py
@@ -7,6 +7,7 @@ import urllib
 from datetime import date, datetime
 
 import requests
+from unidecode import unidecode
 
 from pg_spot_operator.constants import DEFAULT_CONFIG_DIR
 from pg_spot_operator.util import get_aws_region_code_to_name_mapping
@@ -58,7 +59,7 @@ def get_ondemand_pricing_info_via_http(region: str) -> dict:
 
     url = f"https://b0.p.awsstatic.com/pricing/2.0/meteredUnitMaps/ec2/USD/current/ec2-ondemand-without-sec-sel/{region_location}/Linux/index.json"
 
-    sanitized_url = urllib.parse.quote(url, safe=":/")
+    sanitized_url = urllib.parse.quote(unidecode(url), safe=":/")
     logger.debug("requests.get: %s", sanitized_url)
     f = requests.get(
         sanitized_url, headers={"Content-Type": "application/json"}, timeout=5
@@ -67,7 +68,7 @@ def get_ondemand_pricing_info_via_http(region: str) -> dict:
         logger.error(
             "Failed to retrieve AWS pricing info - retcode: %s, URL: %s",
             f.status_code,
-            url,
+            sanitized_url,
         )
         return {}
     return f.json()

--- a/pg_spot_operator/cloud_impl/aws_spot.py
+++ b/pg_spot_operator/cloud_impl/aws_spot.py
@@ -201,7 +201,7 @@ def filter_instance_types_by_hw_req(
     cpu_min: int | None = 0,
     cpu_max: int | None = 0,
     ram_min: int | None = 0,
-    architecture: str | None = "any",
+    cpu_arch: str = "",
     storage_min: int | None = 0,
     storage_type: str = "network",
     allow_burstable: bool = True,
@@ -217,10 +217,11 @@ def filter_instance_types_by_hw_req(
         ):
             continue
 
-        if architecture and architecture.strip() and architecture != "any":
-            if (
-                architecture.strip() not in ii.arch
-            ):  # On AWS architectures are named x86_64 and arm64
+        if cpu_arch and cpu_arch.strip() and cpu_arch.strip().lower() != "any":
+            # On AWS architectures are named x86_64 and arm64, but we only look for arm / not-arm for now
+            if "arm" in cpu_arch.strip().lower() and "arm" not in ii.arch:
+                continue
+            if "arm" not in cpu_arch.strip().lower() and "arm" in ii.arch:
                 continue
 
         if allow_burstable is False and ii.is_burstable:
@@ -378,7 +379,7 @@ def get_cheapest_sku_for_hw_reqs(
         cpu_min=cpu_min,
         cpu_max=cpu_max,
         ram_min=ram_min,
-        architecture=architecture,
+        cpu_arch=architecture,
         storage_min=storage_min,
         storage_type=storage_type,
         allow_burstable=allow_burstable,

--- a/pg_spot_operator/cloud_impl/aws_spot.py
+++ b/pg_spot_operator/cloud_impl/aws_spot.py
@@ -390,6 +390,9 @@ def get_cheapest_sku_for_hw_reqs(
         "%s of them matching min HW reqs", len(filtered_instances_by_cpu)
     )
 
+    if not filtered_instances_by_cpu:
+        return []
+
     if len(filtered_instances_by_cpu) > MAX_SKUS_FOR_SPOT_PRICE_COMPARE:
         logger.debug(
             "Reducing to %s instance types by CPU count to reduce pricing history fetching",

--- a/pg_spot_operator/cloud_impl/aws_spot.py
+++ b/pg_spot_operator/cloud_impl/aws_spot.py
@@ -197,7 +197,7 @@ def get_current_hourly_ondemand_price_fallback(
 
 
 def filter_instance_types_by_hw_req(
-    instance_types: list[InstanceTypeInfo],
+    all_instance_types: list[InstanceTypeInfo],
     cpu_min: int | None = 0,
     cpu_max: int | None = 0,
     ram_min: int | None = 0,
@@ -206,11 +206,16 @@ def filter_instance_types_by_hw_req(
     storage_type: str = "network",
     allow_burstable: bool = True,
     storage_speed_class: str | None = "any",
+    instance_types: list[str] | None = None,
     instance_types_to_avoid: list[str] | None = None,
 ) -> list[InstanceTypeInfo]:
     """Returns qualified SKUs sorted by (CPU, RAM) or (CPU, Total instance storage DESC)"""
     ret: list[InstanceTypeInfo] = []
-    for ii in instance_types:
+    for ii in all_instance_types:
+
+        if instance_types and ii.instance_type not in instance_types:
+            continue
+
         if (
             instance_types_to_avoid
             and ii.instance_type in instance_types_to_avoid
@@ -363,6 +368,7 @@ def get_cheapest_sku_for_hw_reqs(
     storage_min: int = 0,
     allow_burstable: bool = True,
     storage_speed_class: str = "any",
+    instance_types: list[str] | None = None,
     instance_types_to_avoid: list[str] | None = None,
     instance_selection_strategy: str | None = None,
 ) -> list[InstanceTypeInfo]:
@@ -384,6 +390,7 @@ def get_cheapest_sku_for_hw_reqs(
         storage_type=storage_type,
         allow_burstable=allow_burstable,
         storage_speed_class=storage_speed_class,
+        instance_types=instance_types,
         instance_types_to_avoid=instance_types_to_avoid,
     )
 

--- a/pg_spot_operator/cloud_impl/aws_vm.py
+++ b/pg_spot_operator/cloud_impl/aws_vm.py
@@ -442,8 +442,8 @@ def ec2_launch_instance(
             }
         )
 
-    logger.debug(
-        f"Launching new {market_type} instance of type {instance_type} in region {region}..."
+    logger.info(
+        f"Launching a new {market_type} instance of type {instance_type} in region {region} ..."
     )
 
     client = get_client("ec2", region)

--- a/pg_spot_operator/cloud_impl/cloud_structs.py
+++ b/pg_spot_operator/cloud_impl/cloud_structs.py
@@ -11,6 +11,7 @@ class InstanceTypeInfo:
     availability_zone: str = ""
     hourly_spot_price: float = 0
     monthly_spot_price: float = 0
+    hourly_ondemand_price: float = 0
     monthly_ondemand_price: float = 0
     cpu: int = 0
     ram_mb: int = 0

--- a/pg_spot_operator/cloud_impl/cloud_structs.py
+++ b/pg_spot_operator/cloud_impl/cloud_structs.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 
 @dataclass
-class ResolvedInstanceTypeInfo:
+class InstanceTypeInfo:
     instance_type: str
     arch: str
     cloud: str

--- a/pg_spot_operator/cloud_impl/cloud_structs.py
+++ b/pg_spot_operator/cloud_impl/cloud_structs.py
@@ -16,6 +16,7 @@ class InstanceTypeInfo:
     ram_mb: int = 0
     instance_storage: int = 0
     storage_speed_class: str = "hdd"
+    is_burstable: bool = False
     provider_description: dict = field(default_factory=dict)
 
 

--- a/pg_spot_operator/cloud_impl/cloud_structs.py
+++ b/pg_spot_operator/cloud_impl/cloud_structs.py
@@ -9,6 +9,7 @@ class InstanceTypeInfo:
     cloud: str
     region: str
     availability_zone: str = ""
+    hourly_spot_price: float = 0
     monthly_spot_price: float = 0
     monthly_ondemand_price: float = 0
     cpu: int = 0

--- a/pg_spot_operator/cmdb.py
+++ b/pg_spot_operator/cmdb.py
@@ -554,13 +554,12 @@ def finalize_ensure_vm(
 
         session.commit()
         logger.info(
-            "OK - %s VM with name %s (ip_public = %s , ip_private = %s) registered for instance %s. Provider ID: %s",
+            "OK - %s VM %s registered for 'instance' %s (ip_public = %s , ip_private = %s)",
             m.cloud,
-            vm.provider_name or "NONAME",
+            vm.provider_id,
+            m.instance_name,
             vm.ip_public,
             vm.ip_private,
-            m.instance_name,
-            vm.provider_id,
         )
 
 

--- a/pg_spot_operator/cmdb.py
+++ b/pg_spot_operator/cmdb.py
@@ -160,7 +160,7 @@ class IgnoredInstance(Base):
 
 def init_engine_and_check_connection(sqlite_connstr: str):
     sqlite_path = os.path.expanduser(sqlite_connstr)
-    logger.info("Initializing CMDB sqlite3 engine at %s ...", sqlite_path)
+    logger.debug("Initializing CMDB sqlite3 engine at %s ...", sqlite_path)
     if not os.path.exists(os.path.dirname(sqlite_path)):
         os.mkdir(os.path.dirname(sqlite_path))
     global engine

--- a/pg_spot_operator/cmdb.py
+++ b/pg_spot_operator/cmdb.py
@@ -22,10 +22,7 @@ from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 
 from pg_spot_operator import manifests, util
-from pg_spot_operator.cloud_impl.cloud_structs import (
-    CloudVM,
-    ResolvedInstanceTypeInfo,
-)
+from pg_spot_operator.cloud_impl.cloud_structs import CloudVM, InstanceTypeInfo
 from pg_spot_operator.cmdb_impl import sqlite
 from pg_spot_operator.manifests import InstanceManifest
 
@@ -504,7 +501,7 @@ def get_ssh_connstr(m: InstanceManifest) -> str:
 
 
 def finalize_ensure_vm(
-    m: InstanceManifest, i_info: ResolvedInstanceTypeInfo, vm: CloudVM
+    m: InstanceManifest, i_info: InstanceTypeInfo, vm: CloudVM
 ):
     if not (
         vm.provider_id and vm.instance_type and vm.login_user and vm.ip_private

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -35,7 +35,7 @@ from pg_spot_operator.cloud_impl.aws_vm import (
     release_address_by_allocation_id_in_region,
     terminate_instances_in_region,
 )
-from pg_spot_operator.cloud_impl.cloud_structs import ResolvedInstanceTypeInfo
+from pg_spot_operator.cloud_impl.cloud_structs import InstanceTypeInfo
 from pg_spot_operator.cloud_impl.cloud_util import (
     extract_cpu_arch_from_sku_desc,
 )
@@ -43,6 +43,7 @@ from pg_spot_operator.cmdb import get_instance_connect_string, get_ssh_connstr
 from pg_spot_operator.constants import (
     BACKUP_TYPE_PGBACKREST,
     CLOUD_AWS,
+    DEFAULT_CONFIG_DIR,
     MF_SEC_VM_STORAGE_TYPE_LOCAL,
     SPOT_OPERATOR_EXPIRES_TAG,
 )
@@ -60,7 +61,6 @@ ACTION_MAX_DURATION = 600
 VM_KEEPALIVE_SCANNER_INTERVAL_S = 60
 ACTION_HANDLER_TEMP_SPACE_ROOT = "~/.pg-spot-operator/tmp"
 ANSIBLE_DEFAULT_ROOT_PATH = "./ansible"
-DEFAULT_CONFIG_DIR = "~/.pg-spot-operator"
 
 logger = logging.getLogger(__name__)
 
@@ -82,9 +82,9 @@ class UserExit(Exception):
 def preprocess_ensure_vm_action(
     m: InstanceManifest,
     existing_instance_info: dict | None = None,
-) -> ResolvedInstanceTypeInfo:
+) -> InstanceTypeInfo:
     """Fill in the "blanks" that are not set by the user but still needed, like the SKU"""
-    sku: ResolvedInstanceTypeInfo
+    sku: InstanceTypeInfo
     selected_instance_type = (
         m.vm.instance_types[0] if len(m.vm.instance_types) == 1 else ""
     )
@@ -118,7 +118,7 @@ def preprocess_ensure_vm_action(
             )
 
         i_desc = describe_instance_type(selected_instance_type, m.region)
-        sku = ResolvedInstanceTypeInfo(
+        sku = InstanceTypeInfo(
             instance_type=selected_instance_type,
             cloud=CLOUD_AWS,
             region=m.region,

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -92,7 +92,7 @@ def preprocess_ensure_vm_action(
         selected_instance_type = existing_instance_info["InstanceType"]
     else:
         logger.info(
-            "Resolving HW requirements in region %s using strategy '%s' ...",
+            "Resolving HW requirements in region %s using --selection-strategy=%s ...",
             m.region,
             m.vm.instance_selection_strategy,
         )
@@ -591,7 +591,7 @@ def run_action(action: str, m: InstanceManifest) -> tuple[bool, dict]:
     - Collect "output" folder contents on successful exit
     """
 
-    logging.info(
+    logging.debug(
         "Starting Ansible action %s for instance %s ...",
         action,
         m.instance_name,
@@ -677,9 +677,9 @@ def ensure_vm(m: InstanceManifest) -> tuple[bool, str]:
         logger.info("Backing instance found: %s", instance_id)
     else:
         logger.warning(
-            "Detected a missing VM for instance %s (%s) - %s ...",
+            "Detected a missing VM for instance '%s' in region %s - %s ...",
             m.instance_name,
-            m.cloud,
+            m.region,
             "NOT creating (--dry-run)" if dry_run else "creating",
         )
         cmdb.mark_any_active_vms_as_deleted(m)
@@ -923,7 +923,7 @@ def do_main_loop(
             if cli_env_manifest:
                 (
                     logger.info(
-                        "Processing manifest for instance %s set via ENV ...",
+                        "Processing manifest for instance '%s' set via CLI / ENV ...",
                         cli_env_manifest.instance_name,
                     )
                     if first_loop
@@ -1144,9 +1144,8 @@ def do_main_loop(
 
             else:
                 logger.info(
-                    "No state changes detected for instance %s (%s)",
+                    "No state changes detected for instance '%s'",
                     m.instance_name,
-                    m.cloud,
                 )
                 raise NoOp()
 

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import math
 import os
 import shutil
 import signal
@@ -172,12 +173,13 @@ def preprocess_ensure_vm_action(
             / sku.monthly_ondemand_price
         )
         logger.info(
-            "Current Spot discount rate for SKU %s in region %s = %s%% (spot $%s vs on-demand $%s)",
-            sku.instance_type,
-            m.region,
+            "Current Spot vs Ondemand discount rate: %s%% ($%s vs $%s), approx. %sx to non-HA RDS",
             round(spot_discount, 1),
             sku.monthly_spot_price,
             sku.monthly_ondemand_price,
+            math.ceil(
+                sku.monthly_ondemand_price / sku.monthly_spot_price * 1.5
+            ),
         )
 
     return sku

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -20,3 +20,4 @@ pydantic
 pyyaml
 types-PyYAML
 sqlalchemy
+unidecode

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pydantic
 pyyaml
 types-PyYAML
 sqlalchemy
+unidecode

--- a/tests/test_aws_spot.py
+++ b/tests/test_aws_spot.py
@@ -3,6 +3,9 @@ import unittest
 
 from dateutil.tz import tzutc
 
+from pg_spot_operator.cloud_api import (
+    boto3_api_instance_list_to_instance_type_info,
+)
 from pg_spot_operator.cloud_impl import aws_spot
 from pg_spot_operator.cloud_impl.aws_spot import (
     get_current_hourly_spot_price,
@@ -518,16 +521,19 @@ SPOT_PRICING_INFO_S3_JSON_SAMPLE = {
 
 
 def test_filter_instances():
-    assert len(INSTANCE_LISTING) == 4
+    iti = boto3_api_instance_list_to_instance_type_info(
+        "dummy-reg", INSTANCE_LISTING
+    )
+    assert len(iti) == 4
     filtered = filter_instance_types_by_hw_req(
-        INSTANCE_LISTING,
+        iti,
         storage_min=10,
         storage_type=MF_SEC_VM_STORAGE_TYPE_LOCAL,
     )
     assert len(filtered) == 2
 
     filtered = filter_instance_types_by_hw_req(
-        INSTANCE_LISTING,
+        iti,
     )
     assert len(filtered) == 4
 

--- a/tests/test_aws_spot.py
+++ b/tests/test_aws_spot.py
@@ -14,6 +14,7 @@ from pg_spot_operator.cloud_impl.aws_spot import (
     resolve_instance_type_info,
     get_ondemand_price_for_instance_type_from_aws_regional_pricing_info,
     get_spot_instance_types_with_price_from_s3_pricing_json,
+    extract_memory_mb_from_aws_pricing_memory_string,
 )
 from pg_spot_operator.constants import MF_SEC_VM_STORAGE_TYPE_LOCAL
 
@@ -586,3 +587,13 @@ def test_get_spot_instance_types_with_price_from_s3_pricing_json():
     )
     assert len(x) == 2
     assert x["m6g.xlarge"] > 0.01
+
+
+def test_extract_memory_mb_from_aws_pricing_memory_string():
+    assert extract_memory_mb_from_aws_pricing_memory_string("64 GiB") == int(
+        64 * 1024
+    )
+    assert extract_memory_mb_from_aws_pricing_memory_string("512 MiB") == 512
+    assert extract_memory_mb_from_aws_pricing_memory_string("1 TiB") == int(
+        1 * 1024 * 1024
+    )

--- a/tests/test_cloud_api.py
+++ b/tests/test_cloud_api.py
@@ -1,0 +1,21 @@
+from pg_spot_operator.cloud_api import (
+    boto3_api_instance_list_to_instance_type_info,
+)
+from tests.test_aws_spot import INSTANCE_LISTING
+
+
+def test_boto3_api_instance_list_to_instance_type_info():
+
+    iti = boto3_api_instance_list_to_instance_type_info(
+        "eu-north-1", INSTANCE_LISTING
+    )
+    # for i in iti:
+    #     print(i)
+    assert iti
+    assert len(iti) == len(INSTANCE_LISTING)
+    as_dict = {x.instance_type: x for x in iti}
+    assert "arm" in as_dict["r6gd.medium"].arch
+    assert as_dict["r6gd.medium"].instance_storage > 10
+    assert as_dict["r6gd.medium"].storage_speed_class == "ssd"
+    assert as_dict["r6gd.medium"].ram_mb == 8192
+    assert as_dict["r6gd.medium"].cpu == 1

--- a/tests/test_cloud_util.py
+++ b/tests/test_cloud_util.py
@@ -1,0 +1,22 @@
+from pg_spot_operator.cloud_impl.cloud_util import (
+    extract_instance_storage_size_and_type_from_aws_pricing_storage_string,
+)
+
+
+def test_extract_instance_storage_size_and_type_from_aws_pricing_storage_string():
+    test_strings = [
+        ("125 GB NVMe SSD", (125, "nvme")),
+        ("1 x 100 NVMe SSD", (100, "nvme")),
+        ("2 x 1900 NVMe SSD", (3800, "nvme")),
+        ("8 x 3840 GB SSD", (30720, "ssd")),
+        ("10 sadasd", (10, "hdd")),
+        ("EBS only", (0, "")),
+    ]
+    for ss, ret in test_strings:
+        # print(ss, ret)
+        assert (
+            extract_instance_storage_size_and_type_from_aws_pricing_storage_string(
+                ss
+            )
+            == ret
+        )


### PR DESCRIPTION
Don't require AWS creds for --check-price mode - a huge usabilty / first impression fix

Can lie a bit as AWS static S3 price files are a bit more stale than boto3 calls but seems almost the same