### PR TITLE
CLI - add flags to set volume type, iops, bandwith

### DIFF
--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -35,6 +35,9 @@
 
 * **--storage-min / PGSO_STORAGE_MIN** Minimal disk size (in GB) to allocate. For local storage instances the actual size might be bigger.
 * **--storage-type / PGSO_STORAGE_TYPE** (Default: network) Allowed values: \[ network | local \].
+* **--volume-type / VOLUME_TYPE** Allowed values: \[ gp2, gp3\*, io1, io2 \]
+* **--volume-iops / VOLUME_IOPS** Set IOPS explicitly. Max. gp2/gp3=16K, io1=64K, io2=256K, gp3 def=3K
+* **--volume-throughput / VOLUME_THROUGHPUT** Set gp3 volume throughput explicitly in MiB/s. Max 1000. Default 125.
 * **--cpu-min / PGSO_CPU_MIN** Minimal CPUs to consider an instance type suitable
 * **--cpu-max / PGSO_CPU_MAX** Maximum CPUs to consider an instance type suitable. Required for the random selection strategy to cap the costs. 
 * **--ram-min / PGSO_RAM_MIN** Minimal RAM (in GB) to consider an instance type suitable

--- a/example_manifests/hello_aws.yaml
+++ b/example_manifests/hello_aws.yaml
@@ -29,8 +29,7 @@ vm:
   volume_type: gp3  # gp2, gp3, io1, io2 Details: https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html
 #  volume_iops:  # For provisioned / paid IOPS, EBS gp3 default is 3000
                 # gp2 / gp3 max 16K, io1 64K, io2 256K
-#  volume_throughput:  # MBs. For provisioned / paid throughput for gp3, io1 and io2. gp3 default is 125
-                      # gp2 max 250, gp3 / io1 max 1000, io2 max 4000. PS Not that not all instance types can achieve max!
+#  volume_throughput:  # MBs. For provisioned / paid throughput for gp3. Default is 125, max 1000.
   detailed_monitoring: false  # As incurs extra costs
 os:
   unattended_security_upgrades: true  # Might result in nightly restarts

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -228,6 +228,9 @@ def compile_manifest_from_cmdline_params(
     m.vm.ram_min = args.ram_min
     m.vm.storage_min = args.storage_min
     m.vm.storage_type = args.storage_type
+    m.vm.volume_type = args.volume_type
+    m.vm.volume_iops = args.volume_iops
+    m.vm.volume_throughput = args.volume_throughput
     if args.instance_types:
         for ins_type in args.instance_types.split(","):
             m.vm.instance_types.append(ins_type)

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -103,6 +103,15 @@ class ArgumentParser(Tap):
     ram_min: int = int(os.getenv("PGSO_RAM_MIN", "0"))
     storage_min: int = int(os.getenv("PGSO_STORAGE_MIN", "0"))
     storage_type: str = os.getenv("PGSO_STORAGE_TYPE", "network")
+    volume_type: str = os.getenv(
+        "PGSO_VOLUME_TYPE", "gp3"
+    )  # gp2, gp3, io1, io2
+    volume_iops: int = int(
+        os.getenv("PGSO_VOLUME_IOPS", "0")
+    )  # max. gp2/gp3=16K, io1=64K, io2=256K, gp3 def=3K
+    volume_throughput: int = int(
+        os.getenv("PGSO_VOLUME_THROUGHPUT", "0")
+    )  # gp3 def=125, max=1000, relevant only for gp3
     expiration_date: str = os.getenv(
         "PGSO_EXPIRATION_DATE", ""
     )  # ISO 8601 datetime


### PR DESCRIPTION
Relevant only for network storage. New flags: `--volume-type`, `--volume-iops`, `--volume-throughput`
