### PR TITLE
Add option to select / filter suitable instances based on instance type family regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,22 +111,23 @@ and feed the output into `--aws-vpc-id`, `--aws-access-key-id` and `--aws-secret
 # General idea
 
 * The user:
-  - Specifies a few key parameters like region, minimum CPUs/RAM and storage size and type (network EBS volumes
-    or local volatile storage) and maybe also the Postgres version (defaults to latest stable). User input can come in 3 forms:
-    - CLI/Env parameters a la `--instance-name`, `--region`, `--cpu-min`, `--storage-min`. Note that in CLI mode not all
+  - Specifies a few key parameters like region (required), and optionally some minimum hardware specs - CPU, RAM, target instance
+  families / generations, or a list of suitable instance types explicitly and for local storage also the min. storage size, and maybe also
+  the Postgres version (defaults to latest stable) and some addon extensions. User input can come in 3 forms:
+    - CLI/Env parameters a la `--region`, `--instance-name`, `--ram-min`, `--assign-public-ip`. Note that in CLI mode not all
       features can be configured and some common choices are made for the user
     - A YAML manifest as literal text via `--manifest`/`PGSO_MANIFEST`
     - A YAML manifest file via `--manifest-path`/`PGSO_MANIFEST_PATH`. To get an idea of all possible options/features
       one could take a look at an example manifest [here](https://github.com/pg-spot-ops/pg-spot-operator/blob/main/example_manifests/hello_aws.yaml)
-  - Specifies or mounts (Docker) the cloud credentials if no default AWS CLI (`~/.aws/credentials`) set up
-  - Can optionally specify also a callback (executable file) to do something/integrate with the resulting connect
-    string (just displayed by default) or just run in `--connstr-output-only` mode to be pipe-friendly
+  - Specifies AWS credentials if no default AWS CLI (`~/.aws/credentials`) set up or if using Docker
+  - Optionally specifies a callback (executable file) to do something with the resulting Postgres connect
+    string (just displayed by default), or just runs in `--connstr-output-only` mode to be pipe-friendly
 * The operator:
   - Finds the cheapest Spot instance with OK eviction rate (the default "balanced" `--selection-strategy`) for given HW
     requirements and launches a VM
   - Runs Ansible to set up Postgres
-  - Keeps checking the VM health every minute (configurable) and if evicted, launches a new one, re-mounts the data
-    volume or does a PITR restore from S3 and resurrects Postgres
+  - Keeps checking the VM health every minute (configurable via `--main-loop-interval-s`) and if eviction detected, launches
+    a new VM, re-mounts the data volume or does a PITR restore from S3 (if `--storage-type=local` + S3 creds set) and resurrects Postgres
 
 # Usage
 

--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -43,7 +43,8 @@
 * **--ram-min / PGSO_RAM_MIN** Minimal RAM (in GB) to consider an instance type suitable
 * **--selection-strategy / PGSO_SELECTION_STRATEGY** (Default: balanced) Allowed values: \[ balanced | cheapest | eviction-rate | random \]. Random can work better when getting a lot of evictions. 
 * **--instance-types / PGSO_INSTANCE_TYPES** To explicitly control the instance type selection. E.g. "i3.xlarge,i3.2xlarge"
-* **--cpu-architecture / PGSO_CPU_ARCH** arm / intel / amd / x86
+* **--instance-family / PGSO_INSTANCE_FAMILY** Regex. e.g. 'r(6|7)'
+* **--cpu-arch / PGSO_CPU_ARCH** arm / intel / amd / x86
 
 # Postgres
 

--- a/example_manifests/hello_aws.yaml
+++ b/example_manifests/hello_aws.yaml
@@ -23,6 +23,7 @@ vm:
   ram_min: 4  # Optional
   allow_burstable: true
   instance_types: [m6gd.xlarge]  # cpu_min etc will be ignored then and cheapest of listed used
+#  instance_family: r(6|7)  # Regex to filter on the first part of instance type names, i.e. "r6g" part of "r6g.medium"
   storage_min: 100  # Required, as no auto-growth for now
   storage_type: local  # local | network. PS Using network volumes pins you to a specific AZ
   storage_speed_class: ssd  # hdd | ssd | nvme. For instance storage (storage_type=local)

--- a/example_manifests/hello_aws.yaml
+++ b/example_manifests/hello_aws.yaml
@@ -2,7 +2,7 @@
 api_version: v1  # Required
 kind: pg_spot_operator_instance  # Required
 cloud: aws  # Required
-#region: eu-south-2  # Optional if availability_zone set
+region: eu-south-2  # Optional if availability_zone set
 #availability_zone: eu-south-2b  # Optional
 instance_name: hello-aws  # Required
 description: My play instance # Optional

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -237,6 +237,7 @@ def compile_manifest_from_cmdline_params(
     if args.instance_types:
         for ins_type in args.instance_types.split(","):
             m.vm.instance_types.append(ins_type)
+    m.vm.instance_family = args.instance_family
     m.vm.host = args.vm_host
     m.vm.login_user = args.vm_login_user
     m.vm.instance_selection_strategy = args.selection_strategy

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -122,6 +122,9 @@ class ArgumentParser(Tap):
         os.getenv("PGSO_ASSIGN_PUBLIC_IP", "true")
     )
     cpu_arch: str = os.getenv("PGSO_CPU_ARCH", "")  # [ arm | x86 ]
+    instance_family: str = os.getenv(
+        "PGSO_INSTANCE_FAMILY", ""
+    )  # Regex, e.g. 'r(6|7)'
     ssh_keys: str = os.getenv("PGSO_SSH_KEYS", "")  # Comma separated
     tuning_profile: str = os.getenv("PGSO_TUNING_PROFILE", "default")
     user_tags: str = os.getenv("PGSO_USER_TAGS", "")  # key=val,key2=val2

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -134,6 +134,7 @@ def resolve_hardware_requirements_to_instance_types(
                     instance_types=m.vm.instance_types,
                     instance_types_to_avoid=skus_to_avoid,
                     instance_selection_strategy=m.vm.instance_selection_strategy,
+                    instance_family=m.vm.instance_family,
                 )
             )
         except Exception as e:

--- a/pg_spot_operator/cloud_impl/cloud_util.py
+++ b/pg_spot_operator/cloud_impl/cloud_util.py
@@ -175,3 +175,12 @@ def is_explicit_aws_region_code(region: str) -> bool:
     if not region or not region.strip():
         return False
     return len(region.split("-")) == 3 and "|" not in region
+
+
+def extract_instance_family_from_instance_type_code(instance_type: str) -> str:
+    """i4g.2xlarge -> i4g"""
+    if not instance_type or "." not in instance_type:
+        raise Exception(
+            f"Unexpected instance_type input - expecting '.' as family separator. Got: {instance_type}"
+        )
+    return instance_type.strip().lower().split(".")[0]

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -65,6 +65,9 @@ class SectionPostgres(BaseModel):
 
 class SectionVm(BaseModel):
     cpu_arch: str = ""
+    instance_family: str = (
+        ""  # Regex on 1st part of instance names, i.e. i4g of i4g.2xlarge
+    )
     allow_burstable: bool = (
         False  # T-class instances tend to get killed more often, thus exclude by default
     )

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -20,7 +20,7 @@ from pg_spot_operator.cloud_impl.aws_s3 import (
     s3_try_create_bucket_if_not_exists,
 )
 from pg_spot_operator.cloud_impl.aws_spot import (
-    describe_instance_type,
+    describe_instance_type_boto3,
     get_backing_vms_for_instances_if_any,
     get_current_hourly_spot_price,
     resolve_instance_type_info,
@@ -118,7 +118,7 @@ def preprocess_ensure_vm_action(
                 )
             )
 
-        i_desc = describe_instance_type(selected_instance_type, m.region)
+        i_desc = describe_instance_type_boto3(selected_instance_type, m.region)
         sku = InstanceTypeInfo(
             instance_type=selected_instance_type,
             cloud=CLOUD_AWS,

--- a/tests/test_aws_spot.py
+++ b/tests/test_aws_spot.py
@@ -589,10 +589,20 @@ def test_filter_instances():
     )
     assert len(filtered) == 2
 
-    filtered = filter_instance_types_by_hw_req(
+    filtered_no_filters = filter_instance_types_by_hw_req(
         iti,
     )
-    assert len(filtered) == 4
+    assert len(filtered_no_filters) == 4
+
+    filtered_instance_family = filter_instance_types_by_hw_req(
+        iti, instance_family="t4"
+    )
+    assert len(filtered_instance_family) == 1
+
+    filtered_instance_family = filter_instance_types_by_hw_req(
+        iti, instance_family="gd"
+    )
+    assert len(filtered_instance_family) == 2
 
 
 def test_get_avg_spot_price_from_pricing_history_data_by_sku_and_az():

--- a/tests/test_cloud_util.py
+++ b/tests/test_cloud_util.py
@@ -1,6 +1,9 @@
+import pytest
+
 from pg_spot_operator.cloud_impl.cloud_util import (
     extract_instance_storage_size_and_type_from_aws_pricing_storage_string,
     is_explicit_aws_region_code,
+    extract_instance_family_from_instance_type_code,
 )
 
 
@@ -29,3 +32,15 @@ def test_is_explicit_aws_region_code():
     assert not is_explicit_aws_region_code("eu-")
     assert not is_explicit_aws_region_code("paris|stock")
     assert not is_explicit_aws_region_code("eu-(ce|no)")
+
+
+def test_extract_instance_type_family():
+    assert (
+        extract_instance_family_from_instance_type_code("i4g.2xlarge") == "i4g"
+    )
+    assert (
+        extract_instance_family_from_instance_type_code("u-24tb1.112xlarge")
+        == "u-24tb1"
+    )
+    with pytest.raises(Exception):
+        extract_instance_family_from_instance_type_code("2xlarge")


### PR DESCRIPTION
Allows to target certain manufacturers ("a" for AMD, "g" for AWS Graviton, "i" for Intel) or memory ("r") or compute ("c" ) optimized instance types

```
python3 -m pg_spot_operator --ram-min 1 --check-price  --storage-type local --storage-min=10 --region eu-north-1 --instance-family i3 
Resolving HW requirements to actual instance types / prices using --selection-strategy=balanced ...
Instance type selected for region eu-north-1: i3en.large (x86)

python3 -m pg_spot_operator --ram-min 1 --check-price  --storage-type local --storage-min=10 --region eu-north-1 --instance-family '^r'
Resolving HW requirements to actual instance types / prices using --selection-strategy=balanced ...
Instance type selected for region eu-north-1: r6gd.large (arm)

```

https://github.com/pg-spot-ops/pg-spot-operator/issues/31