### PR TITLE
New CLI flag --pg-hba-lines to override operator defaults

### DIFF
--- a/ansible/v1/group_vars/all/default_manifest.yml
+++ b/ansible/v1/group_vars/all/default_manifest.yml
@@ -70,7 +70,7 @@ default_manifest:
       track_functions: 'pl'
       track_io_timing: 'on'
       wal_keep_size: '1GB'
-    pg_hba_lines:  # Defaults allow non-postgres world access
+    pg_hba_lines:  # In addition to Debian defaults. Spot Operator defaults allow non-postgres world access
       - "host all postgres 0.0.0.0/0 reject"
       - "hostssl all all 0.0.0.0/0 scram-sha-256"
   backup:  # Only supported backup tool is pgBackRest currently

--- a/ansible/v1/roles/open_pg_instance_access/defaults/main.yml
+++ b/ansible/v1/roles/open_pg_instance_access/defaults/main.yml
@@ -1,8 +1,6 @@
 ---
 # Available in manifests
-instance_name: spot
-postgres:
-  version: 16
+postgres_cluster_name: spot
 
 # Internal
 def_pg_hba_lines:

--- a/ansible/v1/roles/open_pg_instance_access/tasks/main.yml
+++ b/ansible/v1/roles/open_pg_instance_access/tasks/main.yml
@@ -1,12 +1,11 @@
 ---
-- name: Set up pg_hba.conf
-  ansible.builtin.lineinfile:
-    path: "/etc/postgresql/{{ postgres.version|d(16) }}/{{ postgres_cluster_name }}/pg_hba.conf"
-    line: "{{ item }}"
-  loop: "{{ postgres.pg_hba_lines | d([]) or def_pg_hba_lines }}"
-  register: changed
+- name: Set up postgresql.conf in conf.d
+  ansible.builtin.template:
+    src: "pg_hba.conf.j2"
+    dest: "/etc/postgresql/{{ postgres.version|d(16) }}/{{ postgres_cluster_name }}/pg_hba.conf"
+    owner: postgres
+    group: postgres
+    mode: "640"
 
 - name: Reload Postgres config
   ansible.builtin.service: "name=postgresql@{{ postgres.version|d(16) }}-{{ postgres_cluster_name }} state=reloaded"
-  when: changed
-  changed_when: false

--- a/ansible/v1/roles/open_pg_instance_access/templates/pg_hba.conf.j2
+++ b/ansible/v1/roles/open_pg_instance_access/templates/pg_hba.conf.j2
@@ -1,0 +1,17 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     peer
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            scram-sha-256
+# IPv6 local connections:
+host    all             all             ::1/128                 scram-sha-256
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     peer
+host    replication     all             127.0.0.1/32            scram-sha-256
+host    replication     all             ::1/128                 scram-sha-256
+
+{% for hba_line in postgres.pg_hba_lines | d(def_pg_hba_lines) %}
+{{ hba_line }}
+{% endfor %}

--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -57,7 +57,6 @@
 * **--shared-preload-libraries / PGSO_SHARED_PRELOAD_LIBRARIES** (Default: pg_stat_statements). Comma separated
 * **--extensions / PGSO_EXTENSIONS** (Default: pg_stat_statements). Comma separated
 
-
 # Security / Access
 
 * **--aws-access-key-id / PGSO_AWS_ACCESS_KEY_ID** AWS creds. If not set the default profile is used.  
@@ -71,7 +70,8 @@
 * **--aws-subnet-id / PGSO_AWS_SUBNET_ID** To place the created VMs into a specific network
 * **--ssh-keys / PGSO_SSH_KEYS** Comma separated SSH pubkeys to add to the backing VM
 * **--ssh-private-key / PGSO_SSH_PRIVATE_KEY** (Default: ~/.ssh/id_rsa) To use a non-default SSH key to access the VM
-* **--aws-key-pair-name / PGSO_AWS_KEY_PAIR_NAME** To grant an existing AWS SSH key pair SSH access the VM. Must have the private key for actual access 
+* **--aws-key-pair-name / PGSO_AWS_KEY_PAIR_NAME** To grant an existing AWS SSH key pair SSH access the VM. Must have the private key for actual access
+* **--pg-hba-lines / PGSO_PG_HBA_LINES** Valid pg_hba.conf lines to override operator world-access defaults. Comma separated
 
 # Backup
 

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -140,6 +140,9 @@ class ArgumentParser(Tap):
         "PGSO_SHARED_PRELOAD_LIBRARIES", "pg_stat_statements,auth_delay"
     )  # Comma separated
     extensions: str = os.getenv("PGSO_EXTENSIONS", "pg_stat_statements")
+    pg_hba_lines: str = os.getenv(
+        "PGSO_PG_HBA_LINES", ""
+    )  # To override operator default pg_hba access rules. CSV
     aws_access_key_id: str = os.getenv("PGSO_AWS_ACCESS_KEY_ID", "")
     aws_secret_access_key: str = os.getenv("PGSO_AWS_SECRET_ACCESS_KEY", "")
     aws_key_pair_name: str = os.getenv("PGSO_AWS_KEY_PAIR_NAME", "")
@@ -254,6 +257,8 @@ def compile_manifest_from_cmdline_params(
         if args.aws_security_group_ids
         else []
     )
+    if args.pg_hba_lines:
+        m.postgres.pg_hba_lines = args.pg_hba_lines.split(",")
     m.aws.vpc_id = args.aws_vpc_id
     m.aws.subnet_id = args.aws_subnet_id
     m.aws.access_key_id = args.aws_access_key_id

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -59,7 +59,7 @@ class SectionPostgres(BaseModel):
     app_db_name: str | None = None
     config_lines: dict = field(default_factory=dict)
     extensions: list[str] = field(default_factory=list)
-    pg_hba_lines: list[str] = field(default_factory=list)
+    pg_hba_lines: list[str] | None = None
     initdb_opts: list[str] = field(default_factory=list)
 
 


### PR DESCRIPTION
Which might be too wide if SG not trimmed down.

https://github.com/pg-spot-ops/pg-spot-operator/issues/6

For example to only be able to access from your workstation (assuming a stable IP)

```... --pg-hba-lines "host all all $(curl -sL whatismyip.akamai.com)/32 scram-sha-256"```