### PR TITLE
CI test / lint on all modern Python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -225,7 +225,7 @@ def populate_temp_workdir_for_action_exec(
     Also the original manifest + override one will be placed at "input/instance_manifest.yml",
     and for runnables additionally the manifest will be split into flat key-value files under "input"
     """
-    now_str = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d")
+    now_str = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
     temp_workdir = os.path.join(
         os.path.expanduser(temp_workdir_root),
         manifest.instance_name,


### PR DESCRIPTION
3.10,3.11,3.12,3.13