### PR TITLE
Better uptime - create previously fast-failed instance types as last resort only

### DIFF
--- a/pg_spot_operator/cloud_impl/aws_spot.py
+++ b/pg_spot_operator/cloud_impl/aws_spot.py
@@ -60,7 +60,6 @@ def try_get_monthly_ondemand_price_for_sku(region: str, sku: str) -> float:
     hourly: float = 0
     try:
         hourly = get_current_hourly_ondemand_price(region, sku)
-        logger.error("1 %s s%", sku, round(hourly * 24 * 30, 1))
         return round(hourly * 24 * 30, 1)
     except Exception as e:
         logger.error(
@@ -69,7 +68,6 @@ def try_get_monthly_ondemand_price_for_sku(region: str, sku: str) -> float:
         )
     try:
         hourly = get_current_hourly_ondemand_price_fallback(region, sku)
-        logger.error("2 %s s%", sku, round(hourly * 24 * 30, 1))
         return round(hourly * 24 * 30, 1)
     except Exception as e:
         logger.error(

--- a/pg_spot_operator/cmdb_impl/sqlite_migrations.py
+++ b/pg_spot_operator/cmdb_impl/sqlite_migrations.py
@@ -63,7 +63,7 @@ CREATE TABLE vm (
   ip_public text,
   ip_private text NOT NULL,
   user_tags json NOT NULL DEFAULT '{}',
-  created_on datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_on timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   last_modified_on timestamp,
   deleted_on timestamp
 );

--- a/pg_spot_operator/constants.py
+++ b/pg_spot_operator/constants.py
@@ -29,3 +29,5 @@ BACKUP_TYPE_PGBACKREST = "pgbackrest"
 
 
 DEFAULT_CONFIG_DIR = "~/.pg-spot-operator"
+
+DEFAULT_INSTANCE_SELECTION_STRATEGY = "balanced"

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1,7 +1,11 @@
 import pytest
 
 from pg_spot_operator import manifests
-from pg_spot_operator.operator import apply_tuning_profile
+from pg_spot_operator.cloud_impl.cloud_structs import InstanceTypeInfo
+from pg_spot_operator.operator import (
+    apply_tuning_profile,
+    exclude_prev_short_life_time_instances_leaving_at_least_one,
+)
 from .test_manifests import TEST_MANIFEST
 
 
@@ -19,3 +23,60 @@ def test_apply_tuning_profile():
         m, tuning_profiles_path="../tuning_profiles"
     )
     assert len(tuning_lines) > 5
+
+
+def test_exclude_prev_short_life_time_instances_leaving_at_least_one():
+    resolved_instance_types: list[InstanceTypeInfo] = [
+        InstanceTypeInfo(
+            instance_type="i1",
+            region="r1",
+            arch="x86",
+            availability_zone="az1",
+            hourly_spot_price=1,
+        ),
+        InstanceTypeInfo(
+            instance_type="i1",
+            region="r1",
+            arch="x86",
+            availability_zone="az2",
+            hourly_spot_price=2,
+        ),
+        InstanceTypeInfo(
+            instance_type="i2",
+            region="r1",
+            arch="x86",
+            availability_zone="az2",
+            hourly_spot_price=3,
+        ),
+    ]
+
+    assert (
+        len(
+            exclude_prev_short_life_time_instances_leaving_at_least_one(
+                resolved_instance_types, [("i1", "az1")]
+            )
+        )
+        == 2
+    )
+    assert (
+        len(
+            exclude_prev_short_life_time_instances_leaving_at_least_one(
+                resolved_instance_types,
+                [
+                    (x.instance_type, x.availability_zone)
+                    for x in resolved_instance_types
+                ],
+            )
+        )
+        == 1
+    )
+    assert (
+        exclude_prev_short_life_time_instances_leaving_at_least_one(
+            resolved_instance_types,
+            [
+                (x.instance_type, x.availability_zone)
+                for x in resolved_instance_types
+            ],
+        )[0].instance_type
+        == "i1"
+    )

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -4,7 +4,7 @@ from pg_spot_operator import manifests
 from pg_spot_operator.cloud_impl.cloud_structs import InstanceTypeInfo
 from pg_spot_operator.operator import (
     apply_tuning_profile,
-    exclude_prev_short_life_time_instances_leaving_at_least_one,
+    apply_short_life_time_instances_reordering,
 )
 from .test_manifests import TEST_MANIFEST
 
@@ -26,6 +26,7 @@ def test_apply_tuning_profile():
 
 
 def test_exclude_prev_short_life_time_instances_leaving_at_least_one():
+
     resolved_instance_types: list[InstanceTypeInfo] = [
         InstanceTypeInfo(
             instance_type="i1",
@@ -33,6 +34,7 @@ def test_exclude_prev_short_life_time_instances_leaving_at_least_one():
             arch="x86",
             availability_zone="az1",
             hourly_spot_price=1,
+            max_eviction_rate=15,
         ),
         InstanceTypeInfo(
             instance_type="i1",
@@ -40,6 +42,7 @@ def test_exclude_prev_short_life_time_instances_leaving_at_least_one():
             arch="x86",
             availability_zone="az2",
             hourly_spot_price=2,
+            max_eviction_rate=10,
         ),
         InstanceTypeInfo(
             instance_type="i2",
@@ -47,36 +50,45 @@ def test_exclude_prev_short_life_time_instances_leaving_at_least_one():
             arch="x86",
             availability_zone="az2",
             hourly_spot_price=3,
+            max_eviction_rate=5,
         ),
     ]
 
     assert (
         len(
-            exclude_prev_short_life_time_instances_leaving_at_least_one(
+            apply_short_life_time_instances_reordering(
                 resolved_instance_types, [("i1", "az1")]
             )
         )
-        == 2
+        == 3
     )
     assert (
-        len(
-            exclude_prev_short_life_time_instances_leaving_at_least_one(
-                resolved_instance_types,
-                [
-                    (x.instance_type, x.availability_zone)
-                    for x in resolved_instance_types
-                ],
-            )
-        )
-        == 1
+        apply_short_life_time_instances_reordering(
+            resolved_instance_types, [("i1", "az1")]
+        )[-1].instance_type
+        == "i1"
     )
+    # Ev. rate applied if whole shortlist had short lifetime
     assert (
-        exclude_prev_short_life_time_instances_leaving_at_least_one(
+        apply_short_life_time_instances_reordering(
             resolved_instance_types,
             [
                 (x.instance_type, x.availability_zone)
                 for x in resolved_instance_types
             ],
         )[0].instance_type
-        == "i1"
+        == "i2"
+    )
+    # Order left in place if not short lifetime
+    reordered = apply_short_life_time_instances_reordering(
+        resolved_instance_types, [("i2", "az2")]
+    )
+
+    assert (reordered[0].instance_type, reordered[0].availability_zone) == (
+        "i1",
+        "az1",
+    )
+    assert (reordered[1].instance_type, reordered[1].availability_zone) == (
+        "i1",
+        "az2",
     )


### PR DESCRIPTION
If we have eviction pressure let's not try to immediately create the same instance type again but select next one

Some info on that re-ordering in debug mode:
```
2024-12-05 14:15:33,330 DEBUG MainThread cmdb.py:662 Discovered short lifetime (<300s within last 30min) instance types: [('m7gd.medium', 'eu-north-1c')]
2024-12-05 14:15:33,330 DEBUG MainThread operator.py:630 Reordering resolved instances shortlist to prefer recently NOT evicted instance types. Original shortlist: [('m7gd.medium', 'eu-north-1c'), ('c7gd.large', 'eu-north-1c'), ('m7gd.large', 'eu-north-1c')]
2024-12-05 14:15:33,330 DEBUG MainThread operator.py:672 Reordered shortlist: [('c7gd.large', 'eu-north-1c'), ('m7gd.large', 'eu-north-1c'), ('m7gd.medium', 'eu-north-1c')]
```