### PR TITLE
Add an option to get Ansible inventory suitable output in --connstr-output-only mode

### DIFF
--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -30,6 +30,7 @@
 ## Integration
 
 * **--connstr-output-only / PGSO_CONNSTR_OUTPUT_ONLY** Ensure VM + Postgres, output the connstr to stdout and exit. Pipe-friendly
+* **--connstr-format / PGSO_CONNSTR_FORMAT** ssh | ansible. Relevant when --connstr-output-only + --vm-only set
 * **--setup-finished-callback / PGSO_SETUP_FINISHED_CALLBACK** An optional executable to propagate the connect string somewhere
 
 ## Hardware selection

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -719,6 +719,7 @@ def download_ansible_from_github_if_not_set_locally(
     if (
         args.ansible_path
         or args.check_price
+        or args.vm_only
         or args.check_manifest
         or args.teardown
         or args.teardown_region

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -88,6 +88,7 @@ class ArgumentParser(Tap):
     connstr_output_only: bool = str_to_bool(
         os.getenv("PGSO_CONNSTR_OUTPUT_ONLY", "false")
     )  # Set up Postgres, print connstr and exit
+    connstr_output_format: str = os.getenv("PGSO_CONNSTR_OUTPUT_FORMAT", "auto")  # auto | libpq | ssh | ansible. Effective when --connstr-output-only set.
     manifest: str = os.getenv("PGSO_MANIFEST", "")  # Manifest to process
     teardown: bool = str_to_bool(
         os.getenv("PGSO_TEARDOWN", "false")
@@ -973,5 +974,6 @@ def main():  # pragma: no cover
         cli_destroy_file_base_path=args.destroy_file_base_path,
         cli_teardown=args.teardown,
         cli_connstr_output_only=args.connstr_output_only,
+        cli_connstr_output_format=args.connstr_output_format,
         cli_ansible_path=args.ansible_path,
     )

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -88,7 +88,9 @@ class ArgumentParser(Tap):
     connstr_output_only: bool = str_to_bool(
         os.getenv("PGSO_CONNSTR_OUTPUT_ONLY", "false")
     )  # Set up Postgres, print connstr and exit
-    connstr_output_format: str = os.getenv("PGSO_CONNSTR_OUTPUT_FORMAT", "auto")  # auto | libpq | ssh | ansible. Effective when --connstr-output-only set.
+    connstr_format: str = os.getenv(
+        "PGSO_CONNSTR_FORMAT", "ssh"
+    )  # ssh | ansible. Effective currently only when --connstr-output-only and --vm-only set.
     manifest: str = os.getenv("PGSO_MANIFEST", "")  # Manifest to process
     teardown: bool = str_to_bool(
         os.getenv("PGSO_TEARDOWN", "false")
@@ -974,6 +976,6 @@ def main():  # pragma: no cover
         cli_destroy_file_base_path=args.destroy_file_base_path,
         cli_teardown=args.teardown,
         cli_connstr_output_only=args.connstr_output_only,
-        cli_connstr_output_format=args.connstr_output_format,
+        cli_connstr_format=args.connstr_format,
         cli_ansible_path=args.ansible_path,
     )

--- a/pg_spot_operator/cmdb.py
+++ b/pg_spot_operator/cmdb.py
@@ -492,10 +492,8 @@ def get_instance_connect_strings(m: InstanceManifest) -> tuple[str, str]:
     return connstr_private, connstr_public
 
 
-def get_ssh_connstr(
-    m: InstanceManifest, connstr_output_format: str = "ssh"
-) -> str:
-    if connstr_output_format == "ssh":
+def get_ssh_connstr(m: InstanceManifest, connstr_format: str = "ssh") -> str:
+    if connstr_format == "ssh":
         if m.vm.host and m.vm.login_user:
             return f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 -l {m.vm.login_user} {m.vm.host}"
         vm = get_latest_vm_by_uuid(m.uuid)
@@ -504,7 +502,7 @@ def get_ssh_connstr(
         if m.ansible.private_key:
             return f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 -l {vm.login_user} -i {m.ansible.private_key} {vm.ip_public or vm.ip_private}"
         return f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 -l {vm.login_user} {vm.ip_public or vm.ip_private}"
-    elif connstr_output_format == "ansible":
+    elif connstr_format == "ansible":
         if m.vm.host and m.vm.login_user:
             inventory_string = f"{m.vm.host} ansible_user={m.vm.login_user}"
             if m.ansible.private_key:
@@ -526,9 +524,7 @@ def get_ssh_connstr(
 
         return inventory_string
     else:
-        raise Exception(
-            f"Unexpected connstr_output_format: {connstr_output_format}"
-        )
+        raise Exception(f"Unexpected connstr_format: {connstr_format}")
 
 
 def finalize_ensure_vm(m: InstanceManifest, vm: CloudVM):

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -952,7 +952,7 @@ def do_main_loop(
     cli_destroy_file_base_path: str = "",
     cli_teardown: bool = False,
     cli_connstr_output_only: bool = False,
-    cli_connstr_output_format: str = "auto",
+    cli_connstr_format: str = "ssh",
     cli_ansible_path: str = "",
 ):
     global dry_run
@@ -1227,8 +1227,12 @@ def do_main_loop(
             loop_errors = True
 
         if cli_connstr_output_only and not loop_errors:
+            logger.info(
+                "Outputting the %s connect string to stdout and exiting.",
+                cli_connstr_format if m.vm_only else "libpq",
+            )
             if m.vm_only:
-                print(get_ssh_connstr(m, cli_connstr_output_format))
+                print(get_ssh_connstr(m, cli_connstr_format))
             else:
                 print(get_instance_connect_string(m))
             exit(0)

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -952,6 +952,7 @@ def do_main_loop(
     cli_destroy_file_base_path: str = "",
     cli_teardown: bool = False,
     cli_connstr_output_only: bool = False,
+    cli_connstr_output_format: str = "auto",
     cli_ansible_path: str = "",
 ):
     global dry_run
@@ -1227,7 +1228,7 @@ def do_main_loop(
 
         if cli_connstr_output_only and not loop_errors:
             if m.vm_only:
-                print(get_ssh_connstr(m))
+                print(get_ssh_connstr(m, cli_connstr_output_format))
             else:
                 print(get_instance_connect_string(m))
             exit(0)


### PR DESCRIPTION
Via `--connstr-format ansible`. Document also in README and hint that one could use the operator also for non-Postgres tasks