### PR TITLE
List instances improvements - pricing info + human readable uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ pg_spot_operator --region=us-east-1 --instance-name=analytics --teardown
 2024-11-19 11:48:04,251 INFO OK - cloud resources for instance analytics cleaned-up
 ```
 
+Let's double-check that nothing is left hanging from previous experiments:
+
+```
+pg_spot_operator --region='^(us|ca)' --list-instances
+
++---------------+----+------------+--------------+------+----------+----------+--------+------------------+-----------------+-------+-----------------+
+| Instance name | AZ | InstanceId | InstanceType | vCPU | $ (Mon.) | VolumeId | Uptime | PrivateIpAddress | PublicIpAddress | VpcId | Expiration Date |
++---------------+----+------------+--------------+------+----------+----------+--------+------------------+-----------------+-------+-----------------+
++---------------+----+------------+--------------+------+----------+----------+--------+------------------+-----------------+-------+-----------------+
+```
+
 ## Not only for Postgres
 
 Spot Operator can also be used to provision and sustain VMs for any custom workloads, in need of cheap VMs. Relevant

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -942,7 +942,6 @@ def list_instances_and_exit(args: ArgumentParser) -> None:
             instance_descriptions = (
                 get_all_active_operator_instances_from_region(reg)
             )
-            logger.debug("Instances found: %s", len(instance_descriptions))
             if instance_descriptions:
                 instances.extend(instance_descriptions)
         except Exception:

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -933,7 +933,7 @@ def list_instances_and_exit(args: ArgumentParser) -> None:
     instances: list[dict] = []
 
     for reg in regions:
-        logger.info(
+        logger.debug(
             "Fetching non-terminated pg-spot-operator instances for region '%s' ...",
             reg,
         )
@@ -941,7 +941,7 @@ def list_instances_and_exit(args: ArgumentParser) -> None:
             instance_descriptions = (
                 get_all_active_operator_instances_from_region(reg)
             )
-            logger.info("Instances found: %s", len(instance_descriptions))
+            logger.debug("Instances found: %s", len(instance_descriptions))
             if instance_descriptions:
                 instances.extend(instance_descriptions)
         except Exception:

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -30,6 +30,7 @@ from pg_spot_operator.util import (
     extract_region_from_az,
     get_aws_region_code_to_name_mapping,
     region_regex_to_actual_region_codes,
+    timestamp_to_human_readable_delta,
     try_download_ansible_from_github,
 )
 
@@ -956,7 +957,7 @@ def list_instances_and_exit(args: ArgumentParser) -> None:
         "vCPU",
         "$ (Mon.)",
         "VolumeId",
-        "LaunchTime",
+        "Uptime",
         "PrivateIpAddress",
         "PublicIpAddress",
         "VpcId",
@@ -988,7 +989,7 @@ def list_instances_and_exit(args: ArgumentParser) -> None:
                     if len(i.get("BlockDeviceMappings", [])) > 1
                     else None
                 ),
-                i.get("LaunchTime"),
+                timestamp_to_human_readable_delta(i.get("LaunchTime")),
                 i.get("PrivateIpAddress"),
                 i.get("PublicIpAddress"),
                 i.get("VpcId"),

--- a/pg_spot_operator/cloud_impl/aws_spot.py
+++ b/pg_spot_operator/cloud_impl/aws_spot.py
@@ -166,6 +166,8 @@ def get_current_hourly_spot_price_static(
     region: str,
     instance_type: str,
 ) -> float:
+    if not instance_type:
+        return 0
     try:
         all_spot_instances_for_region_with_price = (
             get_spot_instance_types_with_price_from_s3_pricing_json(

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -22,3 +22,4 @@ types-PyYAML
 sqlalchemy
 unidecode
 prettytable
+humanize

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ types-PyYAML
 sqlalchemy
 unidecode
 prettytable
+humanize

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,4 @@
+import datetime
 import tempfile
 
 import pytest
@@ -10,6 +11,7 @@ from pg_spot_operator.util import (
     region_regex_to_actual_region_codes,
     space_pad_manifest,
     merge_user_and_tuned_non_conflicting_config_params,
+    timestamp_to_human_readable_delta,
 )
 from tests.test_manifests import TEST_MANIFEST_VAULT_SECRETS
 
@@ -88,3 +90,10 @@ def test_merge_user_and_tuned_non_conflicting_config_params():
     )
     assert len(merged) == 4
     assert merged["param3"] == "yyy"
+
+
+def test_timestamp_str_to_human_readable_delta():
+    hr = timestamp_to_human_readable_delta(
+        datetime.datetime(2024, 10, 1), datetime.datetime(2024, 12, 1)
+    )
+    assert "month" in hr


### PR DESCRIPTION
More friendly `--list-instances` output. Now looking like:

```
+---------------+-------------+---------------------+--------------+------+----------+-----------------------+--------+------------------+-----------------+--------------+--------------------+
| Instance name |      AZ     |      InstanceId     | InstanceType | vCPU | $ (Mon.) |        VolumeId       | Uptime | PrivateIpAddress | PublicIpAddress |    VpcId     |  Expiration Date   |
+---------------+-------------+---------------------+--------------+------+----------+-----------------------+--------+------------------+-----------------+--------------+--------------------+
|      ram8     | eu-north-1c | i-0e1ee862ba39795d6 |  r6g.medium  |  1   |   10.7   | vol-09a6615da5bf6022d | 8 days |   172.31.12.4    |  16.170.230.53  | vpc-aabbcc   | 2025-02-08 09-0100 |
|   ram8local   | eu-north-1b | i-0577e9db9d652d159 | r6gd.medium  |  1   |   13.0   |          None         | 8 days |   172.31.44.84   |   13.53.34.84   | vpc-aabbcc   |        None        |
+---------------+-------------+---------------------+--------------+------+----------+-----------------------+--------+------------------+-----------------+--------------+--------------------+
```