### PR TITLE
Allow running on persistent VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ ansible-playbook -i inventory mycustom_verification.yml && report_success.sh
 pg_spot_operator --teardown --region=us-east-1 --instance-name custom
 ```
 
+## Persistent VM mode
+
+There's also a `--persistent-vms` flag to use normal long-lived non-spot VMs to just quickly get a self-managed instance
+for some hardware specs.
 
 # General idea
 

--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -10,6 +10,7 @@
 * **--dry-run / PGSO_DRY_RUN** Perform a dry-run VM create + create the Ansible skeleton. For example to check if cloud credentials allow Spot VM creation.
 * **--debug / PGSO_DEBUG** Don't clean up Ansible run files plus extra developer outputs.
 * **--vm-only / PGSO_VM_ONLY** Skip Ansible / Postgres setup
+* **--persistent-vms / PGSO_PERSISTENT_VMS** Run on normal / on-demand VMs instead of Spot. Default: false
 * **--config-dir / PGSO_CONFIG_DIR** (Default: ~/.pg-spot-operator) Where the engine keeps its internal state / configuration
 * **--main-loop-interval-s / PGSO_MAIN_LOOP_INTERVAL_S** (Default: 60)  Main loop sleep time. Reduce a bit to detect failures earlier / improve uptime
 * **--verbose / PGSO_VERBOSE** More chat

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -98,8 +98,8 @@ class ArgumentParser(Tap):
     vm_only: bool = str_to_bool(
         os.getenv("PGSO_VM_ONLY", "false")
     )  # No Ansible / Postgres setup
-    ondemand: bool = str_to_bool(
-        os.getenv("PGSO_ONDEMAND", "false")
+    persistent_vms: bool = str_to_bool(
+        os.getenv("PGSO_PERSISTENT_VMS", "false")
     )  # Use persistent VMs instead of Spot
     connstr_output_only: bool = str_to_bool(
         os.getenv("PGSO_CONNSTR_OUTPUT_ONLY", "false")
@@ -274,7 +274,7 @@ def compile_manifest_from_cmdline_params(
     m.instance_name = args.instance_name
     if not m.region and m.availability_zone:
         m.region = extract_region_from_az(m.availability_zone)
-    m.vm.ondemand = args.ondemand
+    m.vm.persistent_vms = args.persistent_vms
     m.expiration_date = args.expiration_date
     m.assign_public_ip = args.assign_public_ip
     m.integrations.setup_finished_callback = args.setup_finished_callback

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -98,6 +98,9 @@ class ArgumentParser(Tap):
     vm_only: bool = str_to_bool(
         os.getenv("PGSO_VM_ONLY", "false")
     )  # No Ansible / Postgres setup
+    ondemand: bool = str_to_bool(
+        os.getenv("PGSO_ONDEMAND", "false")
+    )  # Use persistent VMs instead of Spot
     connstr_output_only: bool = str_to_bool(
         os.getenv("PGSO_CONNSTR_OUTPUT_ONLY", "false")
     )  # Set up Postgres, print connstr and exit
@@ -271,6 +274,7 @@ def compile_manifest_from_cmdline_params(
     m.instance_name = args.instance_name
     if not m.region and m.availability_zone:
         m.region = extract_region_from_az(m.availability_zone)
+    m.vm.ondemand = args.ondemand
     m.expiration_date = args.expiration_date
     m.assign_public_ip = args.assign_public_ip
     m.integrations.setup_finished_callback = args.setup_finished_callback

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -671,7 +671,8 @@ def display_selected_skus_for_region(
                 ).ljust(max_inst_stor_len),
                 f"{i.monthly_spot_price}",
                 f"{i.monthly_ondemand_price}",
-                f"{ec2_discount_rate}%",
+                f"{ec2_discount_rate}"
+                + ("%" if ec2_discount_rate != "N/A" else ""),
                 approx_rds_x,
                 (
                     i.eviction_rate_group_label

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -61,7 +61,7 @@ def resolve_hardware_requirements_to_instance_types(
 ) -> list[InstanceTypeInfo]:
     """By default prefer to use the direct boto3 APIs to get the most fresh instance and pricing info.
     Use AWS static JSONs for unauthenticated price checks"""
-    logger.info(
+    logger.debug(
         "Resolving HW requirements in region '%s' using --selection-strategy=%s ...",
         m.region,
         m.vm.instance_selection_strategy,

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -126,6 +126,7 @@ def resolve_hardware_requirements_to_instance_types(
                     region,
                     max_skus_to_get,
                     use_boto3=use_boto3,
+                    persistent_vms=m.vm.persistent_vms,
                     availability_zone=m.availability_zone,
                     cpu_min=m.vm.cpu_min,
                     cpu_max=m.vm.cpu_max,

--- a/pg_spot_operator/cloud_impl/aws_spot.py
+++ b/pg_spot_operator/cloud_impl/aws_spot.py
@@ -584,6 +584,8 @@ def resolve_hardware_requirements_to_instance_types(
                 for x in ondemand_sorted
             ],
         )
+        for x in ondemand_sorted:
+            x.spot = False
         return ondemand_sorted[:max_skus_to_get]
 
     instance_types_to_consider = [

--- a/pg_spot_operator/cloud_impl/aws_vm.py
+++ b/pg_spot_operator/cloud_impl/aws_vm.py
@@ -447,11 +447,11 @@ def ec2_launch_instance(
         )
 
     instance_market_options = {}
-    if not m.vm.ondemand:
+    if not m.vm.persistent_vms:
         instance_market_options = {"MarketType": "spot"}
     logger.info(
         "Launching a new %s instance of type %s in region %s ...",
-        "ondemand" if m.vm.ondemand else "spot",
+        "ondemand" if m.vm.persistent_vms else "spot",
         instance_name,
         region,
     )
@@ -498,7 +498,7 @@ def ec2_launch_instance(
     i_az = i["Instances"][0]["Placement"]["AvailabilityZone"]
     logger.debug(
         "New %s %s instance %s launched in AZ %s",
-        "ondemand" if m.vm.ondemand else "spot",
+        "ondemand" if m.vm.persistent_vms else "spot",
         instance_type,
         i_id,
         i_az,

--- a/pg_spot_operator/cloud_impl/aws_vm.py
+++ b/pg_spot_operator/cloud_impl/aws_vm.py
@@ -370,7 +370,6 @@ def ec2_launch_instance(
     key_pair_name: str = m.aws.key_pair_name
     security_group_ids: list[str] = m.aws.security_group_ids
     subnet_id: str = m.aws.subnet_id
-    market_type = "spot"
 
     if not region:
         raise Exception("Instance manifest 'region' input required!")
@@ -447,8 +446,14 @@ def ec2_launch_instance(
             }
         )
 
+    instance_market_options = {}
+    if not m.vm.ondemand:
+        instance_market_options = {"MarketType": "spot"}
     logger.info(
-        f"Launching a new {market_type} instance of type {instance_type} in region {region} ..."
+        "Launching a new %s instance of type %s in region %s ...",
+        "ondemand" if m.vm.ondemand else "spot",
+        instance_name,
+        region,
     )
 
     client = get_client("ec2", region)
@@ -472,7 +477,7 @@ def ec2_launch_instance(
             MinCount=1,
             MaxCount=1,
             ImageId=os_image_id,
-            InstanceMarketOptions={"MarketType": market_type},
+            InstanceMarketOptions=instance_market_options,
             Placement=placement,
             NetworkInterfaces=[network_interface],
             TagSpecifications=tag_spec,
@@ -492,7 +497,11 @@ def ec2_launch_instance(
     i_id = i["Instances"][0]["InstanceId"]
     i_az = i["Instances"][0]["Placement"]["AvailabilityZone"]
     logger.debug(
-        f"New {market_type} {instance_type} instance {i_id} launched in AZ {i_az}"
+        "New %s %s instance %s launched in AZ %s",
+        "ondemand" if m.vm.ondemand else "spot",
+        instance_type,
+        i_id,
+        i_az,
     )
     logger.debug("Waiting for instance 'running' state (timeout 300s) ...")
 

--- a/pg_spot_operator/cloud_impl/cloud_structs.py
+++ b/pg_spot_operator/cloud_impl/cloud_structs.py
@@ -11,6 +11,7 @@ class InstanceTypeInfo:
     region: str
     cloud: str = CLOUD_AWS
     availability_zone: str = ""
+    spot: bool = True
     hourly_spot_price: float = 0
     monthly_spot_price: float = 0
     hourly_ondemand_price: float = 0

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -74,7 +74,7 @@ class SectionVm(BaseModel):
     allow_burstable: bool = (
         False  # T-class instances tend to get killed more often, thus exclude by default
     )
-    ondemand: bool = False
+    persistent_vms: bool = False
     detailed_monitoring: bool = False  # Has extra cost
     cpu_min: int = 0
     cpu_max: int = 0

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -74,6 +74,7 @@ class SectionVm(BaseModel):
     allow_burstable: bool = (
         False  # T-class instances tend to get killed more often, thus exclude by default
     )
+    ondemand: bool = False
     detailed_monitoring: bool = False  # Has extra cost
     cpu_min: int = 0
     cpu_max: int = 0


### PR DESCRIPTION
A new `--persistent-vms` flag to run on normal non-Spot VMs