### PR TITLE
New integration option: connect string storing into a local engine node file

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,15 @@ pg_spot_operator --ram-min=256 --region=us-west-2 --storage-min 300 \
 
 # Integrating with user applications
 
-One can use the Spot Operator also to power real applications, given they cope with the slighyly reduced uptimes of course,
-by either providing a "setup finished" callback script, running in special pipe-friendly `--connstr-output-only` mode or
-pushing the resulting connect information to a S3 bucket. More details in [README_integration.md](https://github.com/pg-spot-ops/pg-spot-operator/blob/main/docs/README_integration.md).
+One can use the Spot Operator also to power real applications, given they cope with the slightly reduced uptimes of course,
+by either:
+
+* Providing a "setup finished" callback script to propagate Postgres / VM connect data somewhere
+* Running in a special pipe-friendly `--connstr-output-only` mode
+* Specifying an S3 (or compatible) bucket where to push the connect string
+* Writing the connect string to a file on the engine node
+
+* More details in [README_integration.md](https://github.com/pg-spot-ops/pg-spot-operator/blob/main/docs/README_integration.md).
 
 PS Real usage assumes that the engine is kept running on a single node only by the user, as there's by design no global
 synchronization / consensus store to keep things simple.

--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -35,7 +35,10 @@
 * **--connstr-output-only / PGSO_CONNSTR_OUTPUT_ONLY** Ensure VM + Postgres, output the connstr to stdout and exit. Pipe-friendly
 * **--connstr-format / PGSO_CONNSTR_FORMAT** ssh | ansible. Relevant when --connstr-output-only + --vm-only set
 * **--setup-finished-callback / PGSO_SETUP_FINISHED_CALLBACK** An optional executable to propagate the connect string somewhere
-* **--setup-finished-callback / PGSO_SETUP_FINISHED_CALLBACK** An optional executable to propagate the connect string somewhere
+    connstr_output_path: str = os.getenv(
+        "CONNSTR_OUTPUT_PATH", ""
+    )  # When set write PG / VM connect string into a file
+* **--connstr-output-path / CONNSTR_OUTPUT_PATH** When set write Postgres (or SSH if --vm-only) connect string into a file
 * **--connstr-bucket / CONNSTR_BUCKET** (Required for S3 push to work)
 * **--connstr-bucket-key / CONNSTR_BUCKET_KEY** (Required for S3 push to work)
 * **--connstr-bucket-region / CONNSTR_BUCKET_REGION** Don't have to be set if region matched with the instance

--- a/docs/README_integration.md
+++ b/docs/README_integration.md
@@ -6,6 +6,7 @@ they cope with the possible service interruptions of course) by either:
 * Providing a "setup finished" callback script to do "something" with the resulting VM / Postgres info
 * Running in special `--connstr-output-only` mode
 * Specifying an S3 (or compatible) bucket where to push the connect string
+* Writing the connect string to a file on the engine node
 
 ## Pipe-friendly `--connstr-output-only` mode
 
@@ -16,6 +17,11 @@ docker run --rm -e PGSO_CONNSTR_OUTPUT_ONLY=y -e PGSO_REGION=eu-north-1 -e PGSO_
   | run_some_testing \ 
   && docker run --rm -e PGSO_TEARDOWN=y -e PGSO_REGION=eu-north-1 -e PGSO_INSTANCE_NAME=pg1
 ```
+
+## Writing the connect string to a file on the engine node
+
+Just specify a full file path via `--connstr-output-path` or `CONNSTR_OUTPUT_PATH`, that the engine node has
+write privileges to.
 
 ## Pushing connect info to S3
 

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -203,6 +203,9 @@ class ArgumentParser(Tap):
     setup_finished_callback: str = os.getenv(
         "PGSO_SETUP_FINISHED_CALLBACK", ""
     )  # An optional executable to propagate the connect string somewhere. Gets connect details as input parameters
+    connstr_output_path: str = os.getenv(
+        "CONNSTR_OUTPUT_PATH", ""
+    )  # When set write Postgres (or SSH if --vm-only) connect string into a file
     connstr_bucket: str = os.getenv(
         "CONNSTR_BUCKET", ""
     )  # An S3 bucket to write the connect string into
@@ -1137,4 +1140,5 @@ def main():  # pragma: no cover
         cli_connstr_output_only=args.connstr_output_only,
         cli_connstr_format=args.connstr_format,
         cli_ansible_path=args.ansible_path,
+        cli_connstr_output_path=args.connstr_output_path,
     )

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -1051,6 +1051,28 @@ def write_connstr_to_s3_if_bucket_set(m: InstanceManifest) -> None:
         return
 
 
+def write_connstr_to_output_path(
+    m: InstanceManifest, connstr_output_path: str, connstr_format: str
+) -> None:
+    """Non-critical"""
+    try:
+        if m.vm_only:
+            connstr = get_ssh_connstr(m, connstr_format)
+        else:
+            connstr = get_instance_connect_string(m)
+        if not connstr:
+            logger.warning(
+                "Could not get a connstr to output to %s", connstr_output_path
+            )
+            return
+        with open(connstr_output_path, "w") as f:
+            f.write(connstr)
+    except Exception as e:
+        logger.error(
+            "Failed to output connstr to %s: Error: %s", connstr_output_path, e
+        )
+
+
 def do_main_loop(
     cli_dry_run: bool = False,
     cli_debug: bool = False,
@@ -1063,6 +1085,7 @@ def do_main_loop(
     cli_connstr_output_only: bool = False,
     cli_connstr_format: str = "ssh",
     cli_ansible_path: str = "",
+    cli_connstr_output_path: str = "",
 ):
     global dry_run
     dry_run = cli_dry_run
@@ -1346,6 +1369,19 @@ def do_main_loop(
             logger.exception("Exception on main loop")
             loop_errors = True
 
+        if cli_dry_run:
+            logger.info("Exiting due to --dry-run")
+            exit(0)
+
+        if cli_connstr_output_path and not loop_errors:
+            logger.info(
+                "Outputting the connect string to %s ...",
+                cli_connstr_output_path,
+            )
+            write_connstr_to_output_path(
+                m, cli_connstr_output_path, cli_connstr_format
+            )
+
         if cli_connstr_output_only and not loop_errors:
             logger.info(
                 "Outputting the %s connect string to stdout and exiting.",
@@ -1358,9 +1394,7 @@ def do_main_loop(
             exit(0)
 
         first_loop = False
-        if cli_dry_run:
-            logger.info("Exiting due to --dry-run")
-            exit(0)
+
         logger.info(
             "Main loop finished. Sleeping for %s s ...",
             cli_main_loop_interval_s,

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -1065,6 +1065,14 @@ def write_connstr_to_output_path(
                 "Could not get a connstr to output to %s", connstr_output_path
             )
             return
+        if os.path.exists(os.path.expanduser(connstr_output_path)):
+            with open(os.path.expanduser(connstr_output_path)) as f:
+                current_file_contents = f.read()
+        if current_file_contents and current_file_contents == connstr:
+            logger.debug(
+                "Not updating the --connstr-output-path as no changes"
+            )
+            return
         with open(connstr_output_path, "w") as f:
             f.write(connstr)
     except Exception as e:


### PR DESCRIPTION
Via `--connstr-output-path` or `CONNSTR_OUTPUT_PATH`