### PR TITLE
New flag to show regional spot stats summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Obviously not meant for all projects as a general RDS replacement, as Spot could
 term setups. Data remains persistent though!
 
 On the other hand - Spot eviction rates are insanely good for the price! The average frequency of interruption is only
-around 5% per month according to AWS [data](https://aws.amazon.com/ec2/spot/instance-advisor/), meaning - one **can expect to run a few months uninterrupted**, i.e.
+around 10% per month according to AWS [data](https://aws.amazon.com/ec2/spot/instance-advisor/), meaning - one **can expect to run a few months uninterrupted**, i.e.
 still in the 99.9+% uptime range!
 
 Based on concepts familiar from the Kubernetes world - user describes a desired state (min. hardware specs, Postgres version,

--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -5,6 +5,7 @@
 * **--list-instances / LIST_INSTANCES** List all running operator managed VMs in specified region(s) and exit
 * **--list-regions / LIST_REGIONS** List AWS datacenter locations and exit
 * **--list-strategies / LIST_STRATEGIES** Display available instance selection strategies and exit
+* **--list-avg-spot-savings / LIST_AVG_SPOT_SAVINGS** Display avg. regional Spot savings and eviction rates to choose the best region. Can apply the --region filter.
 * **--check-price / CHECK_PRICE** Just resolve the HW reqs, show Spot price / discount rate and exit. No AWS creds required.
 * **--check-manifest / CHECK_PRICE** Validate CLI input or instance manifest file and exit
 * **--dry-run / DRY_RUN** Perform a dry-run VM create + create the Ansible skeleton. For example to check if cloud credentials allow Spot VM creation.

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -16,7 +16,10 @@ from pg_spot_operator.cloud_impl.aws_spot import (
     get_current_hourly_spot_price_static,
     try_get_monthly_ondemand_price_for_sku,
 )
-from pg_spot_operator.cloud_impl.cloud_structs import InstanceTypeInfo, RegionalSpotPricingStats
+from pg_spot_operator.cloud_impl.cloud_structs import (
+    InstanceTypeInfo,
+    RegionalSpotPricingStats,
+)
 from pg_spot_operator.cloud_impl.cloud_util import is_explicit_aws_region_code
 from pg_spot_operator.cmdb_impl import schema_manager
 from pg_spot_operator.constants import (
@@ -101,9 +104,9 @@ class ArgumentParser(Tap):
     list_regions: str = str_boolean_false_to_empty_string(
         os.getenv("LIST_REGIONS", "false")
     )  # Display all known AWS region codes + names and exit
-    check_price_regional_stats: str = str_boolean_false_to_empty_string(
-        os.getenv("CHECK_PRICE_REGIONAL_STATS", "false")
-    )  # Display avg region Spot pricing statistics to choose the best region
+    regional_spot_stats: str = str_boolean_false_to_empty_string(
+        os.getenv("CHECK_SPOT_STATS", "false")
+    )  # Display avg region Spot pricing and eviction rates to choose the best region
     list_instances: str = str_boolean_false_to_empty_string(
         os.getenv("LIST_INSTANCES", "false")
     )  # List running VMs for given region / region wildcards
@@ -1101,17 +1104,17 @@ def list_instances_and_exit(args: ArgumentParser) -> None:
     exit(errors)
 
 
-
-
-
-def show_regional_pricing_summary_and_exit(args: ArgumentParser) -> None:
+def show_regional_spot_pricing_and_eviction_summary_and_exit(
+    args: ArgumentParser,
+) -> None:
     if is_explicit_aws_region_code(args.region):
         regions = [args.region]
     else:
         regions = region_regex_to_actual_region_codes(args.region)
         if not regions:
             logger.error(
-                "Could not resolve region regex '%s' to any regions", args.region
+                "Could not resolve region regex '%s' to any regions",
+                args.region,
             )
             exit(1)
     logger.info(
@@ -1125,8 +1128,23 @@ def show_regional_pricing_summary_and_exit(args: ArgumentParser) -> None:
             reg_pricing.append(get_spot_pricing_summary_for_region(reg))
         except Exception as e:
             logger.warning(str(e))
-    # sort
-    print(reg_pricing)
+    reg_pricing.sort(key=lambda x: x.avg_spot_savings_rate)
+
+    table: list[list] = [
+        [
+            "Region",
+            "Avg. Spot Savings %",
+            "Avg. Eviction Rate % (Mo)",
+        ]
+    ]
+    tab = PrettyTable(table[0])
+    for r in reg_pricing:
+        tab.add_rows(
+            [[r.region, r.avg_spot_savings_rate, r.eviction_rate_group_label]]
+        )
+    print(tab)
+
+    # print(reg_pricing)
     exit(0)
 
 
@@ -1155,8 +1173,8 @@ def main():  # pragma: no cover
     if args.list_regions:
         list_regions_and_exit()
 
-    if args.check_price_regional_stats:
-        show_regional_pricing_summary_and_exit(args)
+    if args.regional_spot_stats:
+        show_regional_spot_pricing_and_eviction_summary_and_exit(args)
 
     if args.list_strategies:
         list_strategies_and_exit()

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -1128,7 +1128,7 @@ def show_regional_spot_pricing_and_eviction_summary_and_exit(
             reg_pricing.append(get_spot_pricing_summary_for_region(reg))
         except Exception as e:
             logger.warning(str(e))
-    reg_pricing.sort(key=lambda x: x.avg_spot_savings_rate)
+    reg_pricing.sort(key=lambda x: x.avg_spot_savings_rate, reverse=True)
 
     table: list[list] = [
         [
@@ -1138,9 +1138,18 @@ def show_regional_spot_pricing_and_eviction_summary_and_exit(
         ]
     ]
     tab = PrettyTable(table[0])
+    max_reg_len = max(
+        [len(x.region) for x in reg_pricing]
+    )  # To justify nicely for multi-region
     for r in reg_pricing:
         tab.add_rows(
-            [[r.region, r.avg_spot_savings_rate, r.eviction_rate_group_label]]
+            [
+                [
+                    r.region.ljust(max_reg_len, " "),
+                    r.avg_spot_savings_rate,
+                    r.eviction_rate_group_label,
+                ]
+            ]
         )
     print(tab)
 

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -35,6 +35,7 @@ from pg_spot_operator.manifests import InstanceManifest
 from pg_spot_operator.operator import clean_up_old_logs_if_any
 from pg_spot_operator.pgtuner import TUNING_PROFILES
 from pg_spot_operator.util import (
+    extract_mtf_months_from_eviction_rate_group_label,
     extract_region_from_az,
     get_aws_region_code_to_name_mapping,
     region_regex_to_actual_region_codes,
@@ -1136,6 +1137,7 @@ def show_regional_spot_pricing_and_eviction_summary_and_exit(
             "Avg. Spot EC2 Savings %",
             "Approx. RDS diff",
             "Avg. Eviction Rate % (Mo)",
+            "Mean Time to Eviction (Mo)",
         ]
     ]
     tab = PrettyTable(table[0])
@@ -1153,6 +1155,9 @@ def show_regional_spot_pricing_and_eviction_summary_and_exit(
                     r.avg_spot_savings_rate,
                     f"{approx_rds_savings_mult}x",
                     r.eviction_rate_group_label,
+                    extract_mtf_months_from_eviction_rate_group_label(
+                        r.eviction_rate_group_label
+                    ),
                 ]
             ]
         )

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -4,16 +4,21 @@ from statistics import mean
 from pg_spot_operator.cloud_impl import aws_spot
 from pg_spot_operator.cloud_impl.aws_cache import (
     get_aws_static_ondemand_pricing_info,
-    get_spot_pricing_from_public_json, get_spot_eviction_rates_from_public_json,
+    get_spot_eviction_rates_from_public_json,
+    get_spot_pricing_from_public_json,
 )
 from pg_spot_operator.cloud_impl.aws_spot import (
+    extract_instance_type_eviction_rates_from_public_eviction_info,
     get_all_ec2_spot_instance_types,
     get_all_instance_types_from_aws_regional_pricing_info,
-    get_spot_instance_types_with_price_from_s3_pricing_json,
-    extract_instance_type_eviction_rates_from_public_eviction_info,
     get_eviction_rate_brackets_from_public_eviction_info,
+    get_spot_instance_types_with_price_from_s3_pricing_json,
 )
-from pg_spot_operator.cloud_impl.cloud_structs import InstanceTypeInfo, RegionalSpotPricingStats, EvictionRateInfo
+from pg_spot_operator.cloud_impl.cloud_structs import (
+    EvictionRateInfo,
+    InstanceTypeInfo,
+    RegionalSpotPricingStats,
+)
 from pg_spot_operator.cloud_impl.cloud_util import (
     extract_cpu_arch_from_sku_desc,
 )
@@ -179,19 +184,23 @@ def get_all_operator_vms_in_manifest_region(
     return vms_in_region
 
 
-def summarize_region_spot_pricing(region: str, eviction_rate_infos: dict[str, EvictionRateInfo], regional_spot_instances_with_price: dict[str, float]) -> RegionalSpotPricingStats:
+def summarize_region_spot_pricing(
+    region: str,
+    eviction_rate_infos: dict[str, EvictionRateInfo],
+    regional_spot_instances_with_price: dict[str, float],
+) -> RegionalSpotPricingStats:
     logger.debug("Summarizing Spot statistics for region %s ...", region)
-    print(len(eviction_rate_infos))
-    print(eviction_rate_infos.popitem())
-    print(len(regional_spot_instances_with_price))
-    print(regional_spot_instances_with_price.popitem())
-    avg_max_ev_rate_group = mean([eri.eviction_rate_group for _, eri in eviction_rate_infos.items()])
-    avg_savings_rate = mean([spot_price for _, spot_price in regional_spot_instances_with_price.items()])
-    print('avg_max_ev_rate_group', avg_max_ev_rate_group)
-    print('avg_savings_rate', avg_savings_rate)
+    avg_max_ev_rate_group = mean(
+        [eri.eviction_rate_group for _, eri in eviction_rate_infos.items()]
+    )
+    avg_savings_rate = mean(
+        [
+            spot_price
+            for _, spot_price in regional_spot_instances_with_price.items()
+        ]
+    )
 
     public_ev_rate_infos = get_spot_eviction_rates_from_public_json()
-    print(len(public_ev_rate_infos["instance_types"]))
 
     prices_per_core: list[float] = []
     prices_per_ram_gb: list[float] = []
@@ -205,37 +214,45 @@ def summarize_region_spot_pricing(region: str, eviction_rate_infos: dict[str, Ev
             prices_per_core.append(price_mon / cores)
             prices_per_ram_gb.append(price_mon / float(ram_gb))
 
-    avg_vcpu_price=mean(prices_per_core)
-    print('mean(prices_per_core)')
-    print(mean(prices_per_core))
-    prices_per_ram_gb=mean(prices_per_ram_gb)
-    print('mean(prices_per_ram_gb)')
-    print(prices_per_ram_gb)
+    avg_vcpu_price = mean(prices_per_core)
+    avg_ram_gb_price = mean(prices_per_ram_gb)
 
-    ev_rate_brackets = get_eviction_rate_brackets_from_public_eviction_info(public_ev_rate_infos)
+    ev_rate_brackets = get_eviction_rate_brackets_from_public_eviction_info(
+        public_ev_rate_infos
+    )
     ev_rate_group = round(avg_max_ev_rate_group)
 
     return RegionalSpotPricingStats(
         region=region,
-        avg_spot_savings_rate=avg_savings_rate,
+        avg_spot_savings_rate=round(avg_savings_rate * -100, 1),
         avg_vcpu_price=avg_vcpu_price,
-        avg_ram_gb_price=prices_per_ram_gb,
+        avg_ram_gb_price=avg_ram_gb_price,
         avg_eviction_rate_group=ev_rate_group,
-        eviction_rate_group_label=ev_rate_brackets[ev_rate_group]["label"]
+        eviction_rate_group_label=ev_rate_brackets[ev_rate_group]["label"],
     )
 
 
-def get_spot_pricing_summary_for_region(region: str) -> RegionalSpotPricingStats:
+def get_spot_pricing_summary_for_region(
+    region: str,
+) -> RegionalSpotPricingStats:
     all_spot_instances_for_region_with_price = (
         get_spot_instance_types_with_price_from_s3_pricing_json(
             region, get_spot_pricing_from_public_json()
         )
     )
     if not all_spot_instances_for_region_with_price:
-        raise Exception(f"Could not fetch public Spot pricing info for region {region}")
+        raise Exception(
+            f"Could not fetch public Spot pricing info for region {region}"
+        )
 
-    ev_rates = extract_instance_type_eviction_rates_from_public_eviction_info(region)
+    ev_rates = extract_instance_type_eviction_rates_from_public_eviction_info(
+        region
+    )
     if not all_spot_instances_for_region_with_price:
-        raise Exception(f"Could not fetch public Spot eviction rates info for region {region}")
+        raise Exception(
+            f"Could not fetch public Spot eviction rates info for region {region}"
+        )
 
-    return summarize_region_spot_pricing(region, ev_rates, all_spot_instances_for_region_with_price)
+    return summarize_region_spot_pricing(
+        region, ev_rates, all_spot_instances_for_region_with_price
+    )

--- a/pg_spot_operator/cloud_api.py
+++ b/pg_spot_operator/cloud_api.py
@@ -190,14 +190,11 @@ def summarize_region_spot_pricing(
     regional_spot_instances_with_price: dict[str, float],
 ) -> RegionalSpotPricingStats:
     logger.debug("Summarizing Spot statistics for region %s ...", region)
-    avg_max_ev_rate_group = mean(
+    avg_ev_rate_group = mean(
         [eri.eviction_rate_group for _, eri in eviction_rate_infos.items()]
     )
     avg_savings_rate = mean(
-        [
-            spot_price
-            for _, spot_price in regional_spot_instances_with_price.items()
-        ]
+        [eri.spot_savings_rate for _, eri in eviction_rate_infos.items()]
     )
 
     public_ev_rate_infos = get_spot_eviction_rates_from_public_json()
@@ -220,11 +217,11 @@ def summarize_region_spot_pricing(
     ev_rate_brackets = get_eviction_rate_brackets_from_public_eviction_info(
         public_ev_rate_infos
     )
-    ev_rate_group = round(avg_max_ev_rate_group)
+    ev_rate_group = round(avg_ev_rate_group)
 
     return RegionalSpotPricingStats(
         region=region,
-        avg_spot_savings_rate=round(avg_savings_rate * -100, 1),
+        avg_spot_savings_rate=round(avg_savings_rate, 1),
         avg_vcpu_price=avg_vcpu_price,
         avg_ram_gb_price=avg_ram_gb_price,
         avg_eviction_rate_group=ev_rate_group,

--- a/pg_spot_operator/cloud_impl/cloud_structs.py
+++ b/pg_spot_operator/cloud_impl/cloud_structs.py
@@ -64,4 +64,3 @@ class RegionalSpotPricingStats:
     avg_ram_gb_price: float
     avg_eviction_rate_group: int
     eviction_rate_group_label: str
-

--- a/pg_spot_operator/cloud_impl/cloud_structs.py
+++ b/pg_spot_operator/cloud_impl/cloud_structs.py
@@ -54,3 +54,14 @@ class EvictionRateInfo:
     eviction_rate_group: int
     eviction_rate_group_label: str
     eviction_rate_max_pct: int
+
+
+@dataclass
+class RegionalSpotPricingStats:
+    region: str
+    avg_spot_savings_rate: float
+    avg_vcpu_price: float
+    avg_ram_gb_price: float
+    avg_eviction_rate_group: int
+    eviction_rate_group_label: str
+

--- a/pg_spot_operator/cloud_impl/cloud_structs.py
+++ b/pg_spot_operator/cloud_impl/cloud_structs.py
@@ -60,7 +60,5 @@ class EvictionRateInfo:
 class RegionalSpotPricingStats:
     region: str
     avg_spot_savings_rate: float
-    avg_vcpu_price: float
-    avg_ram_gb_price: float
     avg_eviction_rate_group: int
     eviction_rate_group_label: str

--- a/pg_spot_operator/util.py
+++ b/pg_spot_operator/util.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import urllib.request
 import zipfile
+from statistics import mean
 
 import humanize
 import requests
@@ -356,3 +357,26 @@ def timestamp_to_human_readable_delta(
     if not dt2:
         dt2 = datetime.datetime.now(datetime.timezone.utc)
     return humanize.naturaldelta(dt2 - dt1)
+
+
+def extract_numbers_from_string(input: str) -> list[float]:
+    pattern = r"(\d+(?:\.\d+)?)"
+    matches = re.findall(pattern, input)
+    return [float(match) for match in matches]
+
+
+def extract_mtf_months_from_eviction_rate_group_label(
+    ev_rate_range: str,
+) -> int:
+    """Months until get a 50% chance to get evicted
+    10-15% -> 12.5 -> 50 / 12.5 = 4mons
+    Special case: >20% = 0
+    """
+    evic_rate_percentages = extract_numbers_from_string(ev_rate_range)
+    if len(evic_rate_percentages) > 1:
+        avg_evic_rate = mean(evic_rate_percentages)
+    else:
+        avg_evic_rate = evic_rate_percentages[0]
+    if avg_evic_rate >= 20:
+        return 0
+    return round(50 / avg_evic_rate)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -12,6 +12,7 @@ from pg_spot_operator.util import (
     space_pad_manifest,
     merge_user_and_tuned_non_conflicting_config_params,
     timestamp_to_human_readable_delta,
+    extract_mtf_months_from_eviction_rate_group_label,
 )
 from tests.test_manifests import TEST_MANIFEST_VAULT_SECRETS
 
@@ -101,3 +102,9 @@ def test_timestamp_str_to_human_readable_delta():
         datetime.datetime(2024, 10, 1), datetime.datetime(2024, 12, 1)
     )
     assert "month" in hr
+
+
+def test_extract_mtf_months_from_eviction_rate_group_label():
+    assert extract_mtf_months_from_eviction_rate_group_label("<5%") == 10
+    assert extract_mtf_months_from_eviction_rate_group_label("10-15%") == 4
+    assert extract_mtf_months_from_eviction_rate_group_label(">20%") == 0


### PR DESCRIPTION
Via `--list-avg-spot-savings`

```
python3 -m pg_spot_operator --region=eu --list-avg-spot-savings yes
2025-01-07 15:45:40,145 INFO Regions in consideration based on --region='eu' input: ['eu-central-1', 'eu-central-2', 'eu-north-1', 'eu-south-1', 'eu-south-2', 'eu-west-1', 'eu-west-2', 'eu-west-3']
+--------------+-------------------------+------------------+---------------------------+----------------------------+
|    Region    | Avg. Spot EC2 Savings % | Approx. RDS diff | Avg. Eviction Rate % (Mo) | Mean Time to Eviction (Mo) |
+--------------+-------------------------+------------------+---------------------------+----------------------------+
| eu-south-1   |           72.6          |       5.5x       |           10-15%          |             4              |
| eu-south-2   |           69.4          |       4.9x       |           10-15%          |             4              |
| eu-north-1   |           68.2          |       4.7x       |           5-10%           |             7              |
| eu-central-2 |           66.8          |       4.5x       |           10-15%          |             4              |
| eu-central-1 |           66.5          |       4.5x       |           10-15%          |             4              |
| eu-west-3    |           63.0          |       4.1x       |           5-10%           |             7              |
| eu-west-2    |           62.5          |       4.0x       |           10-15%          |             4              |
| eu-west-1    |           54.1          |       3.3x       |           5-10%           |             7              |
+--------------+-------------------------+------------------+---------------------------+----------------------------+
```