### PR TITLE
Revert boolean cli flag handling + rename 2 flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ pg_spot_operator --list-avg-spot-savings yes --region ^eu
   - Specifies a few key parameters like region (required), and optionally some minimum hardware specs - CPU, RAM, target instance
   families / generations, or a list of suitable instance types explicitly and for local storage also the min. storage size, and maybe also
   the Postgres version (v15+ supported, defaults to latest stable) and some addon extensions. User input can come in 3 forms:
-    - CLI/Env parameters a la `--region`, `--instance-name`, `--ram-min`, `--assign-public-ip`. Note that in CLI mode not all
+    - CLI/Env parameters a la `--region`, `--instance-name`, `--ram-min`, `--private-ip-only`. Note that in CLI mode not all
       features can be configured and some common choices are made for the user
     - A YAML manifest as literal text via `--manifest`/`MANIFEST`
     - A YAML manifest file via `--manifest-path`/`MANIFEST_PATH`. To get an idea of all possible options/features

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pipx install --include-deps ansible  # If Ansible not yet installed
 
 # Resolve user requirements to actual EC2 instance types and show the best (cheap and with good eviction rates) instance types.
 # Here we only consider North American regions, assuming were located there and want good latencies as well.
-pg_spot_operator --check-price=yes \
+pg_spot_operator --check-price \
   --region='^(us|ca)' --ram-min=128 \
   --storage-min=500 --storage-type=local
 
@@ -138,7 +138,7 @@ Wow, that task went smooth, other people's computers can be really useful someti
 the instance ...
 
 ```
-pg_spot_operator --region=us-east-1 --instance-name=analytics --teardown=yes
+pg_spot_operator --region=us-east-1 --instance-name=analytics --teardown
 
 2024-11-19 11:48:04,251 INFO Destroying cloud resources if any for instance analytics ...
 ...
@@ -175,7 +175,7 @@ INFO Current expected monthly eviction rate range: <5%
 
 ansible-playbook -i inventory.ini mycustom_verification.yml && report_success.sh
 
-pg_spot_operator --teardown=yes --region=us-east-1 --instance-name custom
+pg_spot_operator --teardown --region=us-east-1 --instance-name custom
 ```
 
 Or add the `--instance-family` flag get some cheap (well, cheapish) Tensor cores for your next AI project:
@@ -290,12 +290,12 @@ pipx install --include-deps ansible
 
 # Let's check prices for some in-memory analytics on our 200GB dataset in all North American regions to get some great $$ value
 # PS in default persistent storage mode (--storage-type=network) we though still pay list price for the EBS volumes (~$0.09/GB)
-pg_spot_operator --check-price=yes --ram-min=256 --region='^(us|ca)'
+pg_spot_operator --check-price --ram-min=256 --region='^(us|ca)'
 
 Resolving HW requirements to actual instance types / prices using --selection-strategy=balanced ...
 Regions in consideration based on --region='^(us|ca)' input: ['ca-central-1', 'ca-west-1', 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']
 Resolving HW requirements in region '^(us|ca)' using --selection-strategy=balanced ...
-Top cheapest instances found for strategy 'balanced' (to list available strategies run --list-strategies/LIST_STRATEGIES=yes):
+Top cheapest instances found for strategy 'balanced' (to list available strategies run --list-strategies / LIST_STRATEGIES=y):
 +--------------+----------------+------+------+--------+------------------+-------------+------------------+--------------+-----------------+-----------------+
 |    Region    |      SKU       | Arch | vCPU |  RAM   | Instance storage | Spot $ (Mo) | On-Demand $ (Mo) | EC2 discount | Approx. RDS win | Evic. rate (Mo) |
 +--------------+----------------+------+------+--------+------------------+-------------+------------------+--------------+-----------------+-----------------+
@@ -324,7 +324,7 @@ One can use the Spot Operator also to power real applications, given they cope w
 by either:
 
 * Providing a "setup finished" callback script to propagate Postgres / VM connect data somewhere
-* Running in a special pipe-friendly `--connstr-only=yes` mode
+* Running in a special pipe-friendly `--connstr-only` mode
 * Specifying an S3 (or compatible) bucket where to push the connect string
 * Writing the connect string to a file on the engine node
 

--- a/ansible/v1/group_vars/all/default_manifest.yml
+++ b/ansible/v1/group_vars/all/default_manifest.yml
@@ -7,7 +7,7 @@ default_manifest:
 #  availability_zone: eu-south-2b  # Optional
 #  instance_name: hello-aws  # Required
 #  description: My play instance # Optional
-  assign_public_ip: true  # Default: true
+  private_ip_only: false  # Default: false
   ip_floating: true  # Default: true, as Elastic IPs are very limited per account
 #  expiration_date: "2024-12-22 00:00+03"  # Optional. Instance will be deleted after that (if engine running)
 #  self_termination: false  # Optional. Instance will auto-destroy itself (if AWS keys )

--- a/ansible/v1/group_vars/all/default_manifest.yml
+++ b/ansible/v1/group_vars/all/default_manifest.yml
@@ -8,7 +8,7 @@ default_manifest:
 #  instance_name: hello-aws  # Required
 #  description: My play instance # Optional
   private_ip_only: false  # Default: false
-  ip_floating: true  # Default: true, as Elastic IPs are very limited per account
+  static_ip_addresses: false  # Default: false, as Elastic IPs are very limited per account
 #  expiration_date: "2024-12-22 00:00+03"  # Optional. Instance will be deleted after that (if engine running)
 #  self_termination: false  # Optional. Instance will auto-destroy itself (if AWS keys )
 #  is_paused: false  # No engine actions on the instance

--- a/docs/README_common_issues.md
+++ b/docs/README_common_issues.md
@@ -64,7 +64,7 @@ aws service-quotas list-service-quotas --service-code ec2 --region eu-north-1 \
 
 ## Enabling all AWS regions
 
-By default some AWS regions of interest might not be enabled, thus causing errors on launching (`--check-price=yes` uses
+By default some AWS regions of interest might not be enabled, thus causing errors on launching (`--check-price` uses
 publicly available data).
 
 Listing not activated regions on the CLI:

--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -83,7 +83,7 @@
 * **--aws-secret-access-key / AWS_SECRET_ACCESS_KEY** AWS creds. If not set the default profile is used.
 * **--self-termination-access-key-id / SELF_TERMINATION_ACCESS_KEY_ID** AWS creds to be placed on the VM if --self-termination set
 * **--self-termination-secret-access-key / SELF_TERMINATION_SECRET_ACCESS_KEY** AWS creds to be placed on the VM if --self-termination set
-* **--assign-public-ip / ASSIGN_PUBLIC_IP** (Default: true) If "false" then only VPC accessible.
+* **--private-ip-only / PRIVATE_IP_ONLY** (Default: false) If "true" then only VPC / private subnet accessible.
 * **--ip-floating / IP_FLOATING** (Default: true) If "false" and in Public IP mode then a fixed Elastic IP is assigned. Has extra cost, plus limited availability on account level usually.
 * **--vault-password-file / VAULT_PASSWORD_FILE** Needed if using Ansible Vault encrypted strings in the manifest
 * **--aws-security-group-ids / AWS_SECURITY_GROUP_IDS** SG rules (a firewall essentially) are "merged" if multiple provided

--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -84,7 +84,7 @@
 * **--self-termination-access-key-id / SELF_TERMINATION_ACCESS_KEY_ID** AWS creds to be placed on the VM if --self-termination set
 * **--self-termination-secret-access-key / SELF_TERMINATION_SECRET_ACCESS_KEY** AWS creds to be placed on the VM if --self-termination set
 * **--private-ip-only / PRIVATE_IP_ONLY** (Default: false) If "true" then only VPC / private subnet accessible.
-* **--ip-floating / IP_FLOATING** (Default: true) If "false" and in Public IP mode then a fixed Elastic IP is assigned. Has extra cost, plus limited availability on account level usually.
+* **--static-ip-addresses / STATIC_IP_ADDRESSES** (Default: false) Set to disable the default "IP floating" behaviour. If "true" and in Public IP mode then a fixed Elastic IP is assigned. Has extra cost, plus limited availability on account level usually.
 * **--vault-password-file / VAULT_PASSWORD_FILE** Needed if using Ansible Vault encrypted strings in the manifest
 * **--aws-security-group-ids / AWS_SECURITY_GROUP_IDS** SG rules (a firewall essentially) are "merged" if multiple provided
 * **--aws-vpc-id / AWS_VPC_ID** If not set default VPC of --region used

--- a/example_manifests/hello_aws.yaml
+++ b/example_manifests/hello_aws.yaml
@@ -6,9 +6,9 @@ region: eu-south-2  # Optional if availability_zone or vm.host set
 #availability_zone: eu-south-2b  # Optional
 instance_name: hello-aws  # Required
 description: My play instance # Optional
-assign_public_ip: true  # Default: true. False = internal / VPC access only. PS Public IPs cost ~$4 per month.
+private_ip_only: false  # Default: false. True = internal / VPC access only. PS Public IPs cost ~$4 per month.
 ip_floating: true  # Default: true. If true we get a new IP after eviction i.e. don't reserve / manage a NIC.
-                    # If false and assign_public_ip set an Elastic IPs will be used (given available, very limited per account)
+                    # If false and private_ip_only set an Elastic IPs will be used (given available, very limited per account)
 #expiration_date: "2024-12-22 00:00+03"  # Optional. Instance will be deleted after that (if engine running)
 self_termination: false  # Optional. Instance will auto-destroy itself (needs according separate AWS keys set)
 is_paused: false  # No engine actions on the instance

--- a/example_manifests/hello_aws.yaml
+++ b/example_manifests/hello_aws.yaml
@@ -7,8 +7,8 @@ region: eu-south-2  # Optional if availability_zone or vm.host set
 instance_name: hello-aws  # Required
 description: My play instance # Optional
 private_ip_only: false  # Default: false. True = internal / VPC access only. PS Public IPs cost ~$4 per month.
-ip_floating: true  # Default: true. If true we get a new IP after eviction i.e. don't reserve / manage a NIC.
-                    # If false and private_ip_only set an Elastic IPs will be used (given available, very limited per account)
+static_ip_addresses: false  # Default: false. By default we get a new IP after eviction i.e. don't reserve / manage a NIC.
+                    # If true and private_ip_only=false an Elastic IPs will be used (given available, limited per account)
 #expiration_date: "2024-12-22 00:00+03"  # Optional. Instance will be deleted after that (if engine running)
 self_termination: false  # Optional. Instance will auto-destroy itself (needs according separate AWS keys set)
 is_paused: false  # No engine actions on the instance

--- a/k8s/README_k8s.md
+++ b/k8s/README_k8s.md
@@ -17,7 +17,7 @@ The operator runs just fine on K8s - a few things to be aware of though:
 # Declaring a K8s service to route to the VM
 
 To create a real K8s service for convenient app usage one needs to:
-  1. Run in non-floating IP mode (`ip_floating: false`)
+  1. Run in non-floating IP mode (`static_ip_addresses: true`)
   2. Create the deployment as normal via `helm install` and note the created public IP
   3. Create a K8s service with a fixed IP endpoint, pointing from the K8s cluster to the VM
   4. Clean up if the instance is destroyed

--- a/k8s/example_deployment.yaml
+++ b/k8s/example_deployment.yaml
@@ -47,7 +47,7 @@ spec:
             value: "mypostgres"
           - name: ADMIN_PASSWORD
             value: "mypostgressecret"
-          - name: ASSIGN_PUBLIC_IP
-            value: "true"
+          - name: PRIVATE_IP_ONLY
+            value: "false"
           - name: SSH_KEYS
             value: "ssh-rsa ..."

--- a/k8s/helm/pg-spot-operator/values.yaml
+++ b/k8s/helm/pg-spot-operator/values.yaml
@@ -61,7 +61,7 @@ env:
     value: "mypostgres"
   - name: ADMIN_PASSWORD
     value: "mypostgressecret"
-  - name: ASSIGN_PUBLIC_IP
-    value: "true"
+  - name: PRIVATE_IP_ONLY
+    value: "false"
   - name: SSH_KEYS
     value: "ssh-rsa ..."

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -178,7 +178,7 @@ class ArgumentParser(Tap):
     self_termination: bool = str_to_bool(
         os.getenv("SELF_TERMINATION", "false")
     )
-    assign_public_ip: bool = str_to_bool(os.getenv("ASSIGN_PUBLIC_IP", "true"))
+    private_ip_only: bool = str_to_bool(os.getenv("PRIVATE_IP_ONLY", "false"))
     ip_floating: bool = str_to_bool(
         os.getenv("IP_FLOATING", "true")
     )  # If "false" and in Public IP mode then a fixed Elastic IP is assigned. Has extra cost, plus limited availability on account level usually.
@@ -306,7 +306,7 @@ def compile_manifest_from_cmdline_params(
         m.region = extract_region_from_az(m.availability_zone)
     m.vm.persistent_vms = args.persistent_vms
     m.expiration_date = args.expiration_date
-    m.assign_public_ip = args.assign_public_ip
+    m.private_ip_only = args.private_ip_only
     m.ip_floating = args.ip_floating
     m.integrations.setup_finished_callback = args.setup_finished_callback
     m.integrations.connstr_bucket = args.connstr_bucket

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -178,10 +178,12 @@ class ArgumentParser(Tap):
     self_termination: bool = str_to_bool(
         os.getenv("SELF_TERMINATION", "false")
     )
-    private_ip_only: bool = str_to_bool(os.getenv("PRIVATE_IP_ONLY", "false"))
-    ip_floating: bool = str_to_bool(
-        os.getenv("IP_FLOATING", "true")
-    )  # If "false" and in Public IP mode then a fixed Elastic IP is assigned. Has extra cost, plus limited availability on account level usually.
+    private_ip_only: bool = str_to_bool(
+        os.getenv("PRIVATE_IP_ONLY", "false")
+    )  # Public IPs (default mode) cost ~$4 a month
+    static_ip_addresses: bool = str_to_bool(
+        os.getenv("STATIC_IP_ADDRESSES", "false")
+    )  # If set and in Public IP mode then a fixed Elastic IP is assigned (has limited availability on account level)
     cpu_arch: str = os.getenv("CPU_ARCH", "")  # [ arm | x86 ]
     instance_family: str = os.getenv(
         "INSTANCE_FAMILY", ""
@@ -307,7 +309,7 @@ def compile_manifest_from_cmdline_params(
     m.vm.persistent_vms = args.persistent_vms
     m.expiration_date = args.expiration_date
     m.private_ip_only = args.private_ip_only
-    m.ip_floating = args.ip_floating
+    m.static_ip_addresses = args.static_ip_addresses
     m.integrations.setup_finished_callback = args.setup_finished_callback
     m.integrations.connstr_bucket = args.connstr_bucket
     m.integrations.connstr_bucket_filename = args.connstr_bucket_key

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -57,11 +57,7 @@ logger = logging.getLogger(__name__)
 def str_to_bool(param: str) -> bool:
     if not param:
         return False
-    if (
-        param.strip().lower() == "on"
-        or param.strip().lower() == "enabled"
-        or param.strip().lower() == "1"
-    ):
+    if param.strip().lower() == "on":
         return True
     if param.strip().lower()[0] == "t":
         return True
@@ -99,50 +95,48 @@ class ArgumentParser(Tap):
     vault_password_file: str = os.getenv(
         "VAULT_PASSWORD_FILE", ""
     )  # Can also be set on instance level
-    verbose: str = str_boolean_false_to_empty_string(
-        os.getenv("VERBOSE", "false")
-    )  # More chat
-    check_price: str = str_boolean_false_to_empty_string(
+    verbose: bool = str_to_bool(os.getenv("VERBOSE", "false"))  # More chat
+    check_price: bool = str_to_bool(
         os.getenv("CHECK_PRICE", "false")
     )  # Resolve HW reqs, show Spot price and exit
-    list_regions: str = str_boolean_false_to_empty_string(
+    list_regions: bool = str_to_bool(
         os.getenv("LIST_REGIONS", "false")
     )  # Display all known AWS region codes + names and exit
-    list_avg_spot_savings: str = str_boolean_false_to_empty_string(
+    list_avg_spot_savings: bool = str_to_bool(
         os.getenv("LIST_AVG_SPOT_SAVINGS", "false")
     )  # Display avg. regional Spot savings and eviction rates to choose the best region. Can apply the --region filter.
-    list_instances: str = str_boolean_false_to_empty_string(
+    list_instances: bool = str_to_bool(
         os.getenv("LIST_INSTANCES", "false")
     )  # List running VMs for given region / region wildcards
-    list_strategies: str = os.getenv(
-        "LIST_STRATEGIES", "false"
+    list_strategies: bool = str_to_bool(
+        os.getenv("LIST_STRATEGIES", "false")
     )  # Display available instance selection strategies and exit
-    check_manifest: str = str_boolean_false_to_empty_string(
+    check_manifest: bool = str_to_bool(
         os.getenv("CHECK_MANIFEST", "false")
     )  # Validate instance manifests and exit
-    dry_run: str = str_boolean_false_to_empty_string(
+    dry_run: bool = str_to_bool(
         os.getenv("DRY_RUN", "false")
     )  # Just resolve the VM instance type
-    debug: str = str_boolean_false_to_empty_string(
+    debug: bool = str_to_bool(
         os.getenv("DEBUG", "false")
     )  # Don't clean up Ansible run files plus extra developer outputs
-    vm_only: str = str_boolean_false_to_empty_string(
+    vm_only: bool = str_to_bool(
         os.getenv("VM_ONLY", "false")
     )  # No Ansible / Postgres setup
-    persistent_vms: str = str_boolean_false_to_empty_string(
+    persistent_vms: bool = str_to_bool(
         os.getenv("PERSISTENT_VMS", "false")
     )  # Use persistent VMs instead of Spot
-    connstr_only: str = str_boolean_false_to_empty_string(
+    connstr_only: bool = str_to_bool(
         os.getenv("CONNSTR_ONLY", "false")
     )  # Set up Postgres, print connstr and exit
     connstr_format: str = os.getenv(
         "CONNSTR_FORMAT", "ssh"
     )  # ssh | ansible. Effective currently only when --connstr-only and --vm-only set.
     manifest: str = os.getenv("MANIFEST", "")  # Manifest to process
-    teardown: str = str_boolean_false_to_empty_string(
+    teardown: bool = str_to_bool(
         os.getenv("TEARDOWN", "false")
     )  # Delete VM and other created resources
-    teardown_region: str = str_boolean_false_to_empty_string(
+    teardown_region: bool = str_to_bool(
         os.getenv("TEARDOWN_REGION", "false")
     )  # Delete all operator tagged resources in region
     instance_name: str = os.getenv(
@@ -159,7 +153,7 @@ class ArgumentParser(Tap):
     zone: str = os.getenv("ZONE", "")
     cpu_min: int = int(os.getenv("CPU_MIN", "0"))
     cpu_max: int = int(os.getenv("CPU_MAX", "0"))
-    allow_burstable: str = str_boolean_false_to_empty_string(
+    allow_burstable: bool = str_to_bool(
         os.getenv("ALLOW_BURSTABLE", "false")
     )  # Allow t-class instance types
     selection_strategy: str = os.getenv("SELECTION_STRATEGY", "balanced")
@@ -181,13 +175,11 @@ class ArgumentParser(Tap):
     expiration_date: str = os.getenv(
         "EXPIRATION_DATE", ""
     )  # ISO 8601 datetime, optionally with time zone
-    self_termination: str = str_boolean_false_to_empty_string(
+    self_termination: bool = str_to_bool(
         os.getenv("SELF_TERMINATION", "false")
     )
-    assign_public_ip: str = str_boolean_false_to_empty_string(
-        os.getenv("ASSIGN_PUBLIC_IP", "true")
-    )
-    ip_floating: str = str_boolean_false_to_empty_string(
+    assign_public_ip: bool = str_to_bool(os.getenv("ASSIGN_PUBLIC_IP", "true"))
+    ip_floating: bool = str_to_bool(
         os.getenv("IP_FLOATING", "true")
     )  # If "false" and in Public IP mode then a fixed Elastic IP is assigned. Has extra cost, plus limited availability on account level usually.
     cpu_arch: str = os.getenv("CPU_ARCH", "")  # [ arm | x86 ]
@@ -265,13 +257,11 @@ class ArgumentParser(Tap):
     backup_retention_days: int = int(os.getenv("BACKUP_RETENTION_DAYS", "1"))
     backup_s3_key: str = os.getenv("BACKUP_S3_KEY", "")
     backup_s3_key_secret: str = os.getenv("BACKUP_S3_KEY_SECRET", "")
-    monitoring: str = str_boolean_false_to_empty_string(
-        os.getenv("MONITORING", "false")
-    )
-    grafana_externally_accessible: str = str_boolean_false_to_empty_string(
+    monitoring: bool = str_to_bool(os.getenv("MONITORING", "false"))
+    grafana_externally_accessible: bool = str_to_bool(
         os.getenv("GRAFANA_EXTERNALLY_ACCESSIBLE", "true")
     )
-    grafana_anonymous: str = str_boolean_false_to_empty_string(
+    grafana_anonymous: bool = str_to_bool(
         os.getenv("GRAFANA_ANONYMOUS", "true")
     )
     ssh_private_key: str = os.getenv(
@@ -288,40 +278,6 @@ def validate_and_parse_args() -> ArgumentParser:
         description="Maintains Postgres on Spot VMs",
         underscores_to_dashes=True,
     ).parse_args()
-
-    args.verbose = str_boolean_false_to_empty_string(args.verbose)
-    args.list_strategies = str_boolean_false_to_empty_string(
-        args.list_strategies
-    )
-    args.check_price = str_boolean_false_to_empty_string(args.check_price)
-    args.list_regions = str_boolean_false_to_empty_string(args.list_regions)
-    args.list_instances = str_boolean_false_to_empty_string(
-        args.list_instances
-    )
-    args.list_strategies = str_boolean_false_to_empty_string(
-        args.list_strategies
-    )
-    args.check_manifest = str_boolean_false_to_empty_string(
-        args.check_manifest
-    )
-    args.dry_run = str_boolean_false_to_empty_string(args.dry_run)
-    args.debug = str_boolean_false_to_empty_string(args.debug)
-    args.vm_only = str_boolean_false_to_empty_string(args.vm_only)
-    args.persistent_vms = str_boolean_false_to_empty_string(
-        args.persistent_vms
-    )
-    args.connstr_only = str_boolean_false_to_empty_string(args.connstr_only)
-    args.teardown = str_boolean_false_to_empty_string(args.teardown)
-    args.teardown_region = str_boolean_false_to_empty_string(
-        args.teardown_region
-    )
-    args.self_termination = str_boolean_false_to_empty_string(
-        args.self_termination
-    )
-    args.assign_public_ip = str_boolean_false_to_empty_string(
-        args.assign_public_ip
-    )
-    args.ip_floating = str_boolean_false_to_empty_string(args.ip_floating)
 
     return args
 
@@ -348,10 +304,10 @@ def compile_manifest_from_cmdline_params(
     m.instance_name = args.instance_name
     if not m.region and m.availability_zone:
         m.region = extract_region_from_az(m.availability_zone)
-    m.vm.persistent_vms = str_to_bool(args.persistent_vms)
+    m.vm.persistent_vms = args.persistent_vms
     m.expiration_date = args.expiration_date
-    m.assign_public_ip = str_to_bool(args.assign_public_ip)
-    m.ip_floating = str_to_bool(args.ip_floating)
+    m.assign_public_ip = args.assign_public_ip
+    m.ip_floating = args.ip_floating
     m.integrations.setup_finished_callback = args.setup_finished_callback
     m.integrations.connstr_bucket = args.connstr_bucket
     m.integrations.connstr_bucket_filename = args.connstr_bucket_key
@@ -359,11 +315,11 @@ def compile_manifest_from_cmdline_params(
     m.integrations.connstr_bucket_endpoint = args.connstr_bucket_endpoint
     m.integrations.connstr_bucket_key = args.connstr_bucket_access_key
     m.integrations.connstr_bucket_secret = args.connstr_bucket_access_secret
-    m.vm_only = str_to_bool(args.vm_only)
+    m.vm_only = args.vm_only
     m.vm.cpu_arch = args.cpu_arch
     m.vm.cpu_min = args.cpu_min
     m.vm.cpu_max = args.cpu_max
-    m.vm.allow_burstable = str_to_bool(args.allow_burstable)
+    m.vm.allow_burstable = args.allow_burstable
     m.vm.ram_min = args.ram_min
     m.vm.ram_max = args.ram_max
     m.vm.os_disk_size = args.os_disk_size
@@ -395,7 +351,7 @@ def compile_manifest_from_cmdline_params(
     m.aws.access_key_id = args.aws_access_key_id
     m.aws.secret_access_key = args.aws_secret_access_key
     m.aws.key_pair_name = args.aws_key_pair_name
-    m.self_termination = str_to_bool(args.self_termination)
+    m.self_termination = args.self_termination
     if args.self_termination:
         m.aws.self_termination_access_key_id = (
             args.self_termination_access_key_id
@@ -435,10 +391,8 @@ def compile_manifest_from_cmdline_params(
     if args.monitoring:
         m.monitoring.prometheus_node_exporter.enabled = True
         m.monitoring.grafana.enabled = True
-        m.monitoring.grafana.anonymous_access = str_to_bool(
-            args.grafana_anonymous
-        )
-        m.monitoring.grafana.externally_accessible = str_to_bool(
+        m.monitoring.grafana.anonymous_access = args.grafana_anonymous
+        m.monitoring.grafana.externally_accessible = (
             args.grafana_externally_accessible
         )
 
@@ -876,7 +830,7 @@ def resolve_manifest_and_display_price(
         logger.info("Top cheapest instances by ondemand price:")
     else:
         logger.info(
-            "Top cheapest instances found for strategy '%s' (to list available strategies run --list-strategies/LIST_STRATEGIES=yes):",
+            "Top cheapest instances found for strategy '%s' (to list available strategies run --list-strategies / LIST_STRATEGIES=y):",
             m.vm.instance_selection_strategy,
         )
 
@@ -1274,7 +1228,7 @@ def main():  # pragma: no cover
             args.region,
             args.aws_access_key_id,
             args.aws_secret_access_key,
-            str_to_bool(args.dry_run),
+            args.dry_run,
         )
         logger.info("Teardown complete")
         exit(0)
@@ -1317,14 +1271,14 @@ def main():  # pragma: no cover
 
     operator.do_main_loop(
         cli_env_manifest=env_manifest,
-        cli_dry_run=str_to_bool(args.dry_run),
-        cli_debug=str_to_bool(args.debug),
+        cli_dry_run=args.dry_run,
+        cli_debug=args.debug,
         cli_vault_password_file=args.vault_password_file,
         cli_user_manifest_path=args.manifest_path,
         cli_main_loop_interval_s=args.main_loop_interval_s,
         cli_destroy_file_base_path=args.destroy_file_base_path,
-        cli_teardown=str_to_bool(args.teardown),
-        cli_connstr_only=str_to_bool(args.connstr_only),
+        cli_teardown=args.teardown,
+        cli_connstr_only=args.connstr_only,
         cli_connstr_format=args.connstr_format,
         cli_ansible_path=args.ansible_path,
         cli_connstr_output_path=args.connstr_output_path,

--- a/pg_spot_operator/cloud_impl/aws_vm.py
+++ b/pg_spot_operator/cloud_impl/aws_vm.py
@@ -339,7 +339,8 @@ def ec2_launch_instance(
     logger.debug("placement %s", placement)
 
     network_interface: dict[str, Any] = {
-        "AssociatePublicIpAddress": m.assign_public_ip and m.ip_floating,
+        "AssociatePublicIpAddress": not m.private_ip_only
+        and m.ip_floating,  # A normal (non-elastic) PIP
         "DeviceIndex": 0,
         "DeleteOnTermination": True,
     }
@@ -916,7 +917,7 @@ def ensure_spot_vm(
     if m.vm.storage_type == STORAGE_TYPE_NETWORK:
         vol_desc = ensure_volume_attached(m, i_desc)
 
-    if m.assign_public_ip and not m.ip_floating:
+    if not m.private_ip_only and not m.ip_floating:
         pip = ensure_public_elastic_ip_attached(
             region, instance_name, i_desc["InstanceId"]
         )

--- a/pg_spot_operator/cloud_impl/aws_vm.py
+++ b/pg_spot_operator/cloud_impl/aws_vm.py
@@ -340,7 +340,7 @@ def ec2_launch_instance(
 
     network_interface: dict[str, Any] = {
         "AssociatePublicIpAddress": not m.private_ip_only
-        and m.ip_floating,  # A normal (non-elastic) PIP
+        and not m.static_ip_addresses,  # A normal (non-elastic) PIP
         "DeviceIndex": 0,
         "DeleteOnTermination": True,
     }
@@ -917,7 +917,7 @@ def ensure_spot_vm(
     if m.vm.storage_type == STORAGE_TYPE_NETWORK:
         vol_desc = ensure_volume_attached(m, i_desc)
 
-    if not m.private_ip_only and not m.ip_floating:
+    if not m.private_ip_only and m.static_ip_addresses:
         pip = ensure_public_elastic_ip_attached(
             region, instance_name, i_desc["InstanceId"]
         )

--- a/pg_spot_operator/cmdb.py
+++ b/pg_spot_operator/cmdb.py
@@ -482,7 +482,7 @@ def get_instance_connect_strings(m: InstanceManifest) -> tuple[str, str]:
             m.postgres.admin_password,
             dbname=m.postgres.app_db_name or "postgres",
         )
-        if m.assign_public_ip and vm and vm.ip_public and m:
+        if not m.private_ip_only and vm and vm.ip_public and m:
             connstr_public = util.compose_postgres_connstr_uri(
                 vm.ip_public if vm.ip_public else m.vm.host,
                 m.postgres.admin_user,

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -202,8 +202,8 @@ class InstanceManifest(BaseModel):
     instance_name: str
     # Optional fields
     private_ip_only: bool = False
-    ip_floating: bool = (
-        True  # If False NIC resources can be left hanging if not cleaned up properly
+    static_ip_addresses: bool = (
+        False  # If True we create an explicit NIC resource
     )
     description: str = ""
     availability_zone: str = ""

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -201,7 +201,7 @@ class InstanceManifest(BaseModel):
     region: str = ""
     instance_name: str
     # Optional fields
-    assign_public_ip: bool = True
+    private_ip_only: bool = False
     ip_floating: bool = (
         True  # If False NIC resources can be left hanging if not cleaned up properly
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,14 +20,6 @@ from pg_spot_operator.cli import str_to_bool, str_boolean_false_to_empty_string
 #     assert len(m.aws.security_group_ids) == 0
 
 
-## TODO
-# tests/test_cli.py:3: in <module>
-#     from pg_spot_operator.cli import (
-# pg_spot_operator/cli.py:8: in <module>
-#     from prettytable import PrettyTable
-# E   ModuleNotFoundError: No module named 'prettytable'
-
-
 def test_str_to_bool():
     assert str_to_bool("True")
     assert str_to_bool("true")


### PR DESCRIPTION
Revert https://github.com/pg-spot-ops/pg-spot-operator/commit/ba65186336d5ae4bc462c57f5d3e1be92b09995f: Change CLI input flags logic - all boolean flags accepting values now

As quite inconvenient and non-pythonic in practice and given most people will probably go for Docker usage anyways.

Rename `--ip-floating` to `--static-ip-addresses` and `--assign-public-ip` to `--private-ip-only` so that all boolean flags would be false by default