### PR TITLE
Disable Linux Transparent Huge Pages directly after boot

### DIFF
--- a/ansible/v1/roles/os_setup/tasks/main.yml
+++ b/ansible/v1/roles/os_setup/tasks/main.yml
@@ -27,3 +27,19 @@
     ignore_errors: true
 
   when: os.kernel_tuning|d(True)
+
+# Disable Transparent Huge Pages, generally considered bad for databases that manage their own memory
+- name: Set up a SystemD unit
+  ansible.builtin.template:
+    src: disable-thp.service.j2
+    dest: /etc/systemd/system/disable-thp.service
+
+- name: Reload daemon
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
+- name: Ensure service
+  ansible.builtin.systemd_service:
+    state: started
+    enabled: true
+    name: disable-thp

--- a/ansible/v1/roles/os_setup/templates/disable-thp.service.j2
+++ b/ansible/v1/roles/os_setup/templates/disable-thp.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Disable Transparent HugePages
+Documentation=https://www.kernel.org/doc/Documentation/vm/transhuge.txt
+DefaultDependencies=no
+Before=sysinit.target
+ConditionPathExists=/sys/kernel/mm/transparent_hugepage/enabled
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo "never" > /sys/kernel/mm/transparent_hugepage/enabled'
+ExecStart=/bin/sh -c 'echo "never" > /sys/kernel/mm/transparent_hugepage/defrag'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
As generally negative for databases that manage their own memory