### PR TITLE
Enable huge pages for large ram skus

### DIFF
--- a/ansible/v1/roles/init_pg_instance/templates/pgspotops.conf.j2
+++ b/ansible/v1/roles/init_pg_instance/templates/pgspotops.conf.j2
@@ -1,6 +1,6 @@
 
 {% for _param in postgres.config_lines | d({}, True) %}
-{% if postgres.config_lines[_param] != None %}
+{% if postgres.config_lines[_param] != None and not _param.startswith("pg_spot_operator_shadow") %}
 {{ _param }} = '{{ postgres.config_lines[_param] }}'
 {% endif %}
 {% endfor %}

--- a/ansible/v1/roles/os_setup/tasks/main.yml
+++ b/ansible/v1/roles/os_setup/tasks/main.yml
@@ -43,3 +43,21 @@
     state: started
     enabled: true
     name: disable-thp
+
+# Activate normal Huge Pages if pg_spot_operator_temp.os_huge_pages_needed PG config tuning key set
+# https://www.cybertec-postgresql.com/en/huge-pages-postgresql/
+- block:
+
+  - name: Setting kernel parameters - vm.nr_hugepages
+    ansible.posix.sysctl:
+      name: vm.nr_hugepages
+      value: "{{ postgres.config_lines.pg_spot_operator_shadow_os_huge_pages_needed | string }}"
+    ignore_errors: true
+
+  - name: Make boot persistent
+    ansible.builtin.raw: echo 'vm.nr_hugepages={{ postgres.config_lines.pg_spot_operator_shadow_os_huge_pages_needed }}' > /etc/sysctl.d/01-nr-hugepages.conf
+
+  when: postgres.config_lines.pg_spot_operator_shadow_os_huge_pages_needed | d(0)
+
+#- fail:
+#    msg: yyy

--- a/ansible/v1/roles/os_setup/tasks/main.yml
+++ b/ansible/v1/roles/os_setup/tasks/main.yml
@@ -58,6 +58,3 @@
     ansible.builtin.raw: echo 'vm.nr_hugepages={{ postgres.config_lines.pg_spot_operator_shadow_os_huge_pages_needed }}' > /etc/sysctl.d/01-nr-hugepages.conf
 
   when: postgres.config_lines.pg_spot_operator_shadow_os_huge_pages_needed | d(0)
-
-#- fail:
-#    msg: yyy

--- a/pg_spot_operator/pgtuner.py
+++ b/pg_spot_operator/pgtuner.py
@@ -123,7 +123,7 @@ def activate_huge_pages(base_tuned: dict[str, Any]) -> dict[str, Any]:
     """Setting a 3% extra margin seems to work. Background - Postgres also wants to pre-allocate some structures for
     connection slots and locks. If set too high the memory for huge pages remains reserved and unavailable for general use.
     """
-    base_tuned["huge_pages"] = "on"
+    base_tuned["huge_pages"] = "try"  # Stay on default 'try' for a test period still instead of 'on' which fails if not enough huge pages available
     base_tuned["huge_page_size"] = "2MB"
     sb_bytes = pg_size_bytes(base_tuned["shared_buffers"])
     base_tuned["pg_spot_operator_shadow_os_huge_pages_needed"] = int(

--- a/pg_spot_operator/util.py
+++ b/pg_spot_operator/util.py
@@ -399,3 +399,38 @@ def check_default_ssh_key_exists_and_readable() -> bool:
             DEFAULT_SSH_PUBKEY_PATH,
         )
         return False
+
+
+def pg_size_bytes(size_str: str) -> int:
+    """Reimplement PG-s pg_size_bytes basically. 1024 based!
+    https://pgpedia.info/p/pg_size_bytes.html
+    """
+    size_units = {
+        "bytes": 1,
+        "byte": 1,
+        "kb": 1024,
+        "k": 1024,
+        "mb": 1024**2,
+        "m": 1024**2,
+        "gb": 1024**3,
+        "g": 1024**3,
+        "tb": 1024**4,
+        "t": 1024**4,
+        "pb": 1024**5,
+        "p": 1024**5,
+    }
+    size_str = size_str.lower()
+    # Regular expression to match the size format
+    match = re.match(r"^\s*([\d.]+)\s*([a-zA-Z]*)\s*$", size_str)
+    if not match:
+        raise ValueError(f"Invalid size format: {size_str}")
+
+    value, unit = match.groups()
+    value = float(value)  # Convert the numeric part to a float
+    unit = unit.lower() if unit else "bytes"  # Default unit is bytes
+
+    if unit not in size_units:
+        raise ValueError(f"Unknown size unit: {unit}")
+
+    # Convert to bytes
+    return int(value * size_units[unit])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,6 +13,7 @@ from pg_spot_operator.util import (
     merge_user_and_tuned_non_conflicting_config_params,
     timestamp_to_human_readable_delta,
     extract_mtf_months_from_eviction_rate_group_label,
+    pg_size_bytes,
 )
 from tests.test_manifests import TEST_MANIFEST_VAULT_SECRETS
 
@@ -108,3 +109,25 @@ def test_extract_mtf_months_from_eviction_rate_group_label():
     assert extract_mtf_months_from_eviction_rate_group_label("<5%") == 10
     assert extract_mtf_months_from_eviction_rate_group_label("10-15%") == 4
     assert extract_mtf_months_from_eviction_rate_group_label(">20%") == 0
+
+
+def test_pg_size_bytes():
+    # Test valid inputs
+    assert pg_size_bytes("10 MB") == 10485760
+    assert pg_size_bytes("1GB") == 1073741824
+    assert pg_size_bytes("512 K") == 524288
+    assert pg_size_bytes("100") == 100  # Default to bytes
+
+    # Test with extra spaces
+    assert pg_size_bytes("  2 TB ") == 2199023255552
+    assert pg_size_bytes("3  PB") == 3377699720527872
+
+    # Test lowercase units
+    assert pg_size_bytes("5m") == 5242880
+
+    # Test edge cases
+    with pytest.raises(ValueError, match=r"Invalid size format: .*"):
+        pg_size_bytes("invalid input")
+
+    with pytest.raises(ValueError, match=r"Unknown size unit: .*"):
+        pg_size_bytes("10 XB")


### PR DESCRIPTION
Enable huge pages for larger (>8GB) Shared Bufffers as can bring visible performance improvements