### PR TITLE
Ami caching

### DIFF
--- a/pg_spot_operator/cloud_impl/aws_cache.py
+++ b/pg_spot_operator/cloud_impl/aws_cache.py
@@ -23,7 +23,7 @@ def get_cached_pricing_dict(cache_file: str) -> dict:
     )
     cache_path = os.path.join(cache_dir, cache_file)
     if os.path.exists(cache_path):
-        logger.debug("Reading cached AWS pricing file: %s", cache_path)
+        # logger.debug("Reading cached AWS pricing file: %s", cache_path)
         try:
             with open(cache_path, "r") as f:
                 return json.loads(f.read())


### PR DESCRIPTION
Cache AMI details per region / cpu arch, as change only about 1x per month and can save some API calls.

```
$ cat .pg-spot-operator/price_cache/aws_ami_eu-north-1_amd64_2025_w8.json

{"PlatformDetails": "Linux/UNIX", "UsageOperation": "RunInstances", "BlockDeviceMappings": [{"Ebs": {"DeleteOnTermination": true, "Iops": 3000, "SnapshotId": "snap-0ab8147bd1888d69e", "VolumeSize": 8, "VolumeType": "gp3", "Throughput": 125, "Encrypted": false}, "DeviceName": "/dev/xvda"}], "Description": "Debian 12 (20250210-2019)", "EnaSupport": true, "Hypervisor": "xen", "ImageOwnerAlias": "amazon", "Name": "debian-12-amd64-20250210-2019", "RootDeviceName": "/dev/xvda", "RootDeviceType": "ebs", "SriovNetSupport": "simple", "VirtualizationType": "hvm", "DeprecationTime": "2027-02-10T17:12:19.000Z", "ImageId": "ami-031a83794c9bd5c6a", "ImageLocation": "amazon/debian-12-amd64-20250210-2019", "State": "available", "OwnerId": "136693071363", "CreationDate": "2025-02-10T17:12:19.000Z", "Public": true, "Architecture": "x86_64", "ImageType": "machine"}
```