### PR TITLE
By default mount data disks also in `--vm-only` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,13 +284,13 @@ PS The SSH key is optional, to be able to access the cloud VM directly from your
 ```bash
 # Install the pg-spot-operator package via pip/pipx, with pipx recommended nowadays:
 pipx install pg-spot-operator
-# When actually launching Postgres instaces a local Ansible installation is also assumed!
-# (not needed for price checking or creating vanilla VMs with the --vm-only flag)
+# When actually launching Postgres instances a local Ansible installation is also assumed!
+# (not needed for price checking or creating vanilla VMs with the --vm-only + --no-mount-disks flags)
 pipx install --include-deps ansible
-# Or follow the offical Ansible docs at:
+# Or follow the official Ansible docs at:
 # https://docs.ansible.com/ansible/2.9/installation_guide/intro_installation.html#installing-ansible
 
-# Let's check prices for some in-memory analytics on our 200GB dataset in all North American regions to get some great $$ value
+# Let's check prices for some in-memory analytics on our 200 GB dataset in all North American regions to get some great $$ value
 # PS in default persistent storage mode (--storage-type=network) we though still pay list price for the EBS volumes (~$0.09/GB)
 pg_spot_operator --check-price --ram-min=256 --region='^(us|ca)'
 

--- a/docs/README_env_options.md
+++ b/docs/README_env_options.md
@@ -11,6 +11,7 @@
 * **--dry-run / DRY_RUN** Perform a dry-run VM create + create the Ansible skeleton. For example to check if cloud credentials allow Spot VM creation.
 * **--debug / DEBUG** Don't clean up Ansible run files plus extra developer outputs.
 * **--vm-only / VM_ONLY** Skip Ansible / Postgres setup
+* **--no-mount-disks / NO_MOUNT_DISKS** Skip data disks mounting via Ansible. Relevant only is --vm-only set.
 * **--persistent-vms / PERSISTENT_VMS** Run on normal / on-demand VMs instead of Spot. Default: false
 * **--config-dir / CONFIG_DIR** (Default: ~/.pg-spot-operator) Where the engine keeps its internal state / configuration
 * **--main-loop-interval-s / MAIN_LOOP_INTERVAL_S** (Default: 60)  Main loop sleep time. Reduce a bit to detect failures earlier / improve uptime

--- a/pg_spot_operator/cli.py
+++ b/pg_spot_operator/cli.py
@@ -126,6 +126,9 @@ class ArgumentParser(Tap):
     vm_only: bool = str_to_bool(
         os.getenv("VM_ONLY", "false")
     )  # No Ansible / Postgres setup
+    no_mount_disks: bool = str_to_bool(
+        os.getenv("NO_MOUNT_DISKS", "false")
+    )  # Skip data disks mounting via Ansible. Relevant only is --vm-only set
     persistent_vms: bool = str_to_bool(
         os.getenv("PERSISTENT_VMS", "false")
     )  # Use persistent VMs instead of Spot
@@ -349,6 +352,7 @@ def compile_manifest_from_cmdline_params(
     m.integrations.connstr_bucket_key = args.connstr_bucket_access_key
     m.integrations.connstr_bucket_secret = args.connstr_bucket_access_secret
     m.vm_only = args.vm_only
+    m.no_mount_disks = args.no_mount_disks
     m.vm.cpu_arch = args.cpu_arch
     m.vm.max_price = args.max_price
     m.vm.cpu_min = args.cpu_min

--- a/pg_spot_operator/constants.py
+++ b/pg_spot_operator/constants.py
@@ -14,6 +14,7 @@ SPOT_OPERATOR_EXPIRES_TAG = "pg-spot-operator-expiration-date"
 
 ACTION_ENSURE_VM = "ensure_vm"
 ACTION_INSTANCE_SETUP = "single_instance_setup"
+ACTION_MOUNT_DISKS = "mount_unattached_disks"
 ACTION_DESTROY_INSTANCE = "destroy_instance"
 ACTION_DESTROY_BACKUPS = "destroy_backups"
 ACTION_TERMINATE_VM = "terminate_vm"

--- a/pg_spot_operator/manifests.py
+++ b/pg_spot_operator/manifests.py
@@ -239,6 +239,7 @@ class InstanceManifest(BaseModel):
     expiration_date: str = ""  # now | '2024-06-11 10:40'
     self_termination: bool = False
     vm_only: bool = False  # No Postgres setup
+    no_mount_disks: bool = False  # No data disk mounting if vm_only set
     is_paused: bool = False
     # *Sections*
     postgres: SectionPostgres = field(default_factory=SectionPostgres)

--- a/pg_spot_operator/operator.py
+++ b/pg_spot_operator/operator.py
@@ -1524,7 +1524,9 @@ def do_main_loop(
                     )
 
                 if m.vm_only:
-                    if m.vm.storage_min != -1:  # -1 denotes EBS OS disk only
+                    if (
+                        m.vm.storage_min != -1 and not m.no_mount_disks
+                    ):  # -1 denotes EBS OS disk only
                         run_action(constants.ACTION_MOUNT_DISKS, m)
                     logger.info("Skipping Postgres setup as vm_only set")
                     logger.info(


### PR DESCRIPTION
Can get the previous "plain VM" only mode via the `--no-mount-disks` flag. Disks are mounted to /var/lib/postgresql